### PR TITLE
feat: implement GitLab member listing for projects and groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Model Context Protocol (MCP) server for GitLab integration, providing tools to
 - Group projects listing
 - Project events retrieval
 - Commit history access
+- Member management (list project and group members)
 - Complete wiki management:
   - Project wiki support (list, get, create, edit, delete pages)
   - Group wiki support (list, get, create, edit, delete pages)
@@ -310,6 +311,30 @@ The server provides the following tools:
     "all": true,
     "with_stats": true,
     "first_parent": true,
+    "page": 1,
+    "per_page": 20
+  }
+  ```
+
+### Member Operations
+
+- `list_project_members`: List all members of a GitLab project (including inherited members)
+
+  ```json
+  {
+    "project_id": "username/project",
+    "query": "search term",
+    "page": 1,
+    "per_page": 20
+  }
+  ```
+
+- `list_group_members`: List all members of a GitLab group (including inherited members)
+
+  ```json
+  {
+    "group_id": "group-name",
+    "query": "search term",
     "page": 1,
     "per_page": 20
   }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -549,3 +549,31 @@ export const UploadGroupWikiAttachmentSchema = z.object({
   content: z.string(),
   branch: z.string().optional()
 });
+
+export const ListProjectMembersSchema = z.object({
+  project_id: z.string(),
+  query: z.string().optional(),
+  page: z.number().optional(),
+  per_page: z.number().optional(),
+});
+
+export const ListGroupMembersSchema = z.object({
+  group_id: z.string(),
+  query: z.string().optional(),
+  page: z.number().optional(),
+  per_page: z.number().optional(),
+});
+
+export const GitLabMemberSchema = z.object({
+  id: z.number(),
+  username: z.string(),
+  name: z.string(),
+  state: z.string(),
+  avatar_url: z.string().optional(),
+  web_url: z.string(),
+  access_level: z.number(),
+  access_level_description: z.string().optional(),
+  expires_at: z.string().nullable(),
+});
+
+export type GitLabMember = z.infer<typeof GitLabMemberSchema>; 


### PR DESCRIPTION
# GitLab Member Listing Feature

## Summary of Changes
Added two new tools to interact with GitLab's member management API:
- `list_project_members`: Lists all members of a GitLab project
- `list_group_members`: Lists all members of a GitLab group

## Purpose/Motivation
This feature enables querying project and group membership information directly through the MCP server, allowing for better integration with GitLab's member management capabilities.

## Implementation Details
- Added member listing methods to `GitLabApi` class
- Added corresponding tool definitions in `index.ts`
- Updated README.md with new tool documentation
- Follows existing codebase patterns for API integration

## Testing Performed
- Manual testing of both tools with MCP Inspector

## Changes
- src/gitlab-api.ts: Added `listProjectMembers` and `listGroupMembers` methods
- src/index.ts: Added tool definitions for member listing
- README.md: Updated documentation with new tools