### PR TITLE
refactor: improve member listing response consistency and pagination

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -5,7 +5,8 @@ import {
   GitLabMergeRequestsResponse,
   GitLabWikiPagesResponse,
   GitLabWikiPage,
-  GitLabWikiAttachment
+  GitLabWikiAttachment,
+  GitLabMembersResponse
 } from './schemas.js';
 
 /**
@@ -17,7 +18,7 @@ import {
 export function formatEventsResponse(events: GitLabEventsResponse) {
   // Create a summary of the events
   const summary = `Found ${events.count} events`;
-  
+
   // Format the events data
   const formattedEvents = events.items.map(event => ({
     id: event.id,
@@ -28,7 +29,7 @@ export function formatEventsResponse(events: GitLabEventsResponse) {
     target_title: event.target_title || null,
     push_data: event.push_data || null
   }));
-  
+
   // Return the formatted response
   return {
     content: [
@@ -47,7 +48,7 @@ export function formatEventsResponse(events: GitLabEventsResponse) {
 export function formatCommitsResponse(commits: GitLabCommitsResponse) {
   // Create a summary of the commits
   const summary = `Found ${commits.count} commits`;
-  
+
   // Format the commits data
   const formattedCommits = commits.items.map(commit => ({
     id: commit.id,
@@ -60,7 +61,7 @@ export function formatCommitsResponse(commits: GitLabCommitsResponse) {
     web_url: commit.web_url,
     stats: commit.stats
   }));
-  
+
   // Return the formatted response
   return {
     content: [
@@ -79,7 +80,7 @@ export function formatCommitsResponse(commits: GitLabCommitsResponse) {
 export function formatIssuesResponse(issues: GitLabIssuesResponse) {
   // Create a summary of the issues
   const summary = `Found ${issues.count} issues`;
-  
+
   // Format the issues data
   const formattedIssues = issues.items.map(issue => ({
     id: issue.id,
@@ -101,7 +102,7 @@ export function formatIssuesResponse(issues: GitLabIssuesResponse) {
     })),
     web_url: issue.web_url
   }));
-  
+
   // Return the formatted response
   return {
     content: [
@@ -120,7 +121,7 @@ export function formatIssuesResponse(issues: GitLabIssuesResponse) {
 export function formatMergeRequestsResponse(mergeRequests: GitLabMergeRequestsResponse) {
   // Create a summary of the merge requests
   const summary = `Found ${mergeRequests.count} merge requests`;
-  
+
   // Format the merge requests data
   const formattedMergeRequests = mergeRequests.items.map(mr => ({
     id: mr.id,
@@ -145,7 +146,7 @@ export function formatMergeRequestsResponse(mergeRequests: GitLabMergeRequestsRe
     })),
     web_url: mr.web_url
   }));
-  
+
   // Return the formatted response
   return {
     content: [
@@ -164,7 +165,7 @@ export function formatMergeRequestsResponse(mergeRequests: GitLabMergeRequestsRe
 export function formatWikiPagesResponse(wikiPages: GitLabWikiPagesResponse) {
   // Create a summary of the wiki pages
   const summary = `Found ${wikiPages.count} wiki pages`;
-  
+
   // Format the wiki pages data
   const formattedWikiPages = wikiPages.items.map(page => ({
     slug: page.slug,
@@ -175,7 +176,7 @@ export function formatWikiPagesResponse(wikiPages: GitLabWikiPagesResponse) {
     updated_at: page.updated_at,
     web_url: page.web_url
   }));
-  
+
   // Return the formatted response
   return {
     content: [
@@ -202,7 +203,7 @@ export function formatWikiPageResponse(wikiPage: GitLabWikiPage) {
     updated_at: wikiPage.updated_at,
     web_url: wikiPage.web_url
   };
-  
+
   // Return the formatted response
   return {
     content: [
@@ -227,12 +228,44 @@ export function formatWikiAttachmentResponse(attachment: GitLabWikiAttachment) {
     commit_id: attachment.commit_id,
     url: attachment.url
   };
-  
+
   // Return the formatted response
   return {
     content: [
       { type: "text", text: `Wiki Attachment: ${attachment.file_name}` },
       { type: "text", text: JSON.stringify(formattedAttachment, null, 2) }
+    ]
+  };
+}
+
+/**
+ * Formats the members response for better readability
+ * 
+ * @param members - The GitLab members response
+ * @returns A formatted response object for the MCP tool
+ */
+export function formatMembersResponse(members: GitLabMembersResponse) {
+  // Create a summary of the members
+  const summary = `Found ${members.count} members`;
+
+  // Format the members data
+  const formattedMembers = members.items.map(member => ({
+    id: member.id,
+    username: member.username,
+    name: member.name,
+    state: member.state,
+    avatar_url: member.avatar_url,
+    web_url: member.web_url,
+    access_level: member.access_level,
+    access_level_description: member.access_level_description,
+    expires_at: member.expires_at
+  }));
+
+  // Return the formatted response
+  return {
+    content: [
+      { type: "text", text: summary },
+      { type: "text", text: JSON.stringify(formattedMembers, null, 2) }
     ]
   };
 }

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -47,6 +47,8 @@ import {
   type WikiPageFormat,
   type FileOperation,
   type GitLabMember,
+  GitLabMembersResponseSchema,
+  type GitLabMembersResponse,
 } from './schemas.js';
 
 /**
@@ -1354,7 +1356,7 @@ export class GitLabApi {
    *
    * @param projectId - The ID or URL-encoded path of the project
    * @param options - Options for listing members
-   * @returns A promise that resolves to the list of project members
+   * @returns A promise that resolves to the members response
    * @throws Will throw an error if the GitLab API request fails
    */
   async listProjectMembers(
@@ -1364,7 +1366,7 @@ export class GitLabApi {
       page?: number;
       per_page?: number;
     } = {}
-  ): Promise<GitLabMember[]> {
+  ): Promise<GitLabMembersResponse> {
     const url = new URL(
       `${this.apiUrl}/projects/${encodeURIComponent(projectId)}/members/all`
     );
@@ -1390,7 +1392,12 @@ export class GitLabApi {
     }
 
     const data = await response.json();
-    return z.array(GitLabMemberSchema).parse(data);
+    const totalCount = parseInt(response.headers.get("X-Total") || "0");
+
+    return GitLabMembersResponseSchema.parse({
+      count: totalCount,
+      items: data
+    });
   }
 
   /**
@@ -1398,7 +1405,7 @@ export class GitLabApi {
    *
    * @param groupId - The ID or URL-encoded path of the group
    * @param options - Options for listing members
-   * @returns A promise that resolves to the list of group members
+   * @returns A promise that resolves to the members response
    * @throws Will throw an error if the GitLab API request fails
    */
   async listGroupMembers(
@@ -1408,7 +1415,7 @@ export class GitLabApi {
       page?: number;
       per_page?: number;
     } = {}
-  ): Promise<GitLabMember[]> {
+  ): Promise<GitLabMembersResponse> {
     const url = new URL(
       `${this.apiUrl}/groups/${encodeURIComponent(groupId)}/members/all`
     );
@@ -1434,6 +1441,11 @@ export class GitLabApi {
     }
 
     const data = await response.json();
-    return z.array(GitLabMemberSchema).parse(data);
+    const totalCount = parseInt(response.headers.get("X-Total") || "0");
+
+    return GitLabMembersResponseSchema.parse({
+      count: totalCount,
+      items: data
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import {
   formatWikiPagesResponse,
   formatWikiPageResponse,
   formatWikiAttachmentResponse,
+  formatMembersResponse
 } from './formatters.js';
 import { isValidISODate } from './utils.js';
 
@@ -606,14 +607,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         const args = ListProjectMembersSchema.parse(request.params.arguments);
         const { project_id, ...options } = args;
         const members = await gitlabApi.listProjectMembers(project_id, options);
-        return { content: [{ type: "text", text: JSON.stringify(members, null, 2) }] };
+        return formatMembersResponse(members);
       }
 
       case "list_group_members": {
         const args = ListGroupMembersSchema.parse(request.params.arguments);
         const { group_id, ...options } = args;
         const members = await gitlabApi.listGroupMembers(group_id, options);
-        return { content: [{ type: "text", text: JSON.stringify(members, null, 2) }] };
+        return formatMembersResponse(members);
       }
 
       default:

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -576,4 +576,12 @@ export const GitLabMemberSchema = z.object({
   expires_at: z.string().nullable(),
 });
 
-export type GitLabMember = z.infer<typeof GitLabMemberSchema>; 
+export type GitLabMember = z.infer<typeof GitLabMemberSchema>;
+
+// GitLab Member Response
+export const GitLabMembersResponseSchema = z.object({
+  count: z.number(),
+  items: z.array(GitLabMemberSchema)
+});
+
+export type GitLabMembersResponse = z.infer<typeof GitLabMembersResponseSchema>; 


### PR DESCRIPTION
- Address feedback from PR #3 (https://github.com/yoda-digital/mcp-gitlab-server/pull/3#issuecomment-2768378256)

- Add GitLabMembersResponseSchema with count and items properties

- Extract X-Total header for pagination metadata

- Add formatMembersResponse function for consistent formatting

- Update member listing methods to use new response format

- Follow same patterns as other list methods (commits, issues, etc.)