### PR TITLE
Fix server version mismatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import packageJson from '../package.json' with { type: 'json' };
 import {
   CallToolRequest,
   CallToolRequestSchema,
@@ -79,7 +80,7 @@ const serverCapabilities: ServerCapabilities = {
 // Create server
 const server = new Server({
   name: "gitlab-mcp-server",
-  version: "0.1.0",
+  version: packageJson.version,
 }, {
   capabilities: serverCapabilities
 });


### PR DESCRIPTION
## Summary
- load package version from package.json
- use that value for the Server version

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684464c46afc83329fd747886d108e31