### PR TITLE
docs: Add API reference for core GitLab MCP tools

### DIFF
--- a/docs/api/create_issue.md
+++ b/docs/api/create_issue.md
@@ -1,0 +1,89 @@
+# create_issue
+
+Create a new issue in a GitLab project.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_id` | string | Yes | Project ID or path (e.g., `"my-org/my-project"` or `"123"`) |
+| `title` | string | Yes | Issue title |
+| `description` | string | No | Issue description (supports Markdown) |
+| `assignee_ids` | number[] | No | Array of user IDs to assign |
+| `milestone_id` | number | No | Milestone ID |
+| `labels` | string | No | Comma-separated label names |
+| `due_date` | string | No | Due date in ISO 8601 format (YYYY-MM-DD) |
+| `confidential` | boolean | No | Whether the issue is confidential |
+
+## Response
+
+```json
+{
+  "id": 84,
+  "iid": 14,
+  "project_id": 3,
+  "title": "Bug: Login fails on mobile",
+  "description": "Users cannot log in on mobile devices...",
+  "state": "opened",
+  "created_at": "2024-01-15T08:30:00.000Z",
+  "updated_at": "2024-01-15T08:30:00.000Z",
+  "labels": ["bug", "mobile"],
+  "milestone": null,
+  "assignees": [],
+  "author": {
+    "id": 25,
+    "username": "john_smith",
+    "name": "John Smith"
+  },
+  "assignee": null,
+  "web_url": "https://gitlab.com/my-org/my-project/-/issues/14"
+}
+```
+
+## Example Usage
+
+### Basic Issue
+```json
+{
+  "project_id": "my-org/my-project",
+  "title": "Bug: Login fails on mobile",
+  "description": "## Steps to Reproduce\n1. Open app\n2. Tap login\n3. Error appears"
+}
+```
+
+### Issue with Labels and Milestone
+```json
+{
+  "project_id": "123",
+  "title": "Feature: Add dark mode",
+  "description": "Users have requested dark mode support",
+  "labels": "enhancement,ui",
+  "milestone_id": 5
+}
+```
+
+### Assigned Issue with Due Date
+```json
+{
+  "project_id": "my-org/my-project",
+  "title": "Security: Update dependencies",
+  "description": "Critical security patches needed",
+  "assignee_ids": [42],
+  "labels": "security,urgent",
+  "due_date": "2024-01-20"
+}
+```
+
+## Related Tools
+
+- [`update_issue`](./update_issue.md) — Update existing issue
+- [`list_issues`](./list_issues.md) — List project issues
+- [`create_issue_note`](./create_issue_note.md) — Add comment to issue
+- [`list_issue_notes`](./list_issue_notes.md) — List issue comments
+
+## Notes
+
+- Project ID can be either numeric ID or path format (`org/project`)
+- Labels should be comma-separated without spaces: `"bug,urgent"` not `"bug, urgent"`
+- Description supports full Markdown including code blocks, lists, tables
+- For confidential issues, user must have appropriate permissions

--- a/docs/api/create_merge_request.md
+++ b/docs/api/create_merge_request.md
@@ -1,0 +1,105 @@
+# create_merge_request
+
+Create a new merge request in a GitLab project.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_id` | string | Yes | Project ID or path |
+| `source_branch` | string | Yes | Source branch name |
+| `target_branch` | string | Yes | Target branch name (usually `main` or `master`) |
+| `title` | string | Yes | MR title |
+| `description` | string | No | MR description (supports Markdown) |
+| `assignee_id` | number | No | User ID to assign as reviewer |
+| `assignee_ids` | number[] | No | Array of user IDs to assign |
+| `milestone_id` | number | No | Milestone ID |
+| `labels` | string | No | Comma-separated label names |
+| `remove_source_branch` | boolean | No | Delete source branch after merge (default: false) |
+| `squash` | boolean | No | Squash commits on merge (default: false) |
+
+## Response
+
+```json
+{
+  "id": 1,
+  "iid": 1,
+  "project_id": 3,
+  "title": "Add new dashboard UI",
+  "description": "Implements redesigned dashboard with dark mode support",
+  "state": "opened",
+  "created_at": "2024-01-15T09:00:00.000Z",
+  "updated_at": "2024-01-15T09:00:00.000Z",
+  "merged_at": null,
+  "closed_at": null,
+  "target_branch": "main",
+  "source_branch": "feature/new-ui",
+  "author": {
+    "id": 25,
+    "username": "john_smith",
+    "name": "John Smith"
+  },
+  "assignee": null,
+  "assignees": [],
+  "labels": [],
+  "work_in_progress": false,
+  "merge_when_pipeline_succeeds": false,
+  "merge_status": "can_be_merged",
+  "has_conflicts": false,
+  "web_url": "https://gitlab.com/my-org/my-project/-/merge_requests/1"
+}
+```
+
+## Example Usage
+
+### Basic Merge Request
+```json
+{
+  "project_id": "my-org/my-project",
+  "source_branch": "feature/new-ui",
+  "target_branch": "main",
+  "title": "Add new dashboard UI",
+  "description": "Implements redesigned dashboard with dark mode support"
+}
+```
+
+### MR with Assignee and Labels
+```json
+{
+  "project_id": "123",
+  "source_branch": "fix/memory-leak",
+  "target_branch": "main",
+  "title": "Fix: Memory leak in pipeline operations",
+  "description": "## Changes\n- Fixed memory leak\n- Added tests\n\n## Testing\n- All tests pass",
+  "assignee_id": 42,
+  "labels": "bug,performance"
+}
+```
+
+### Auto-cleanup MR with Squash
+```json
+{
+  "project_id": "my-org/my-project",
+  "source_branch": "feature/quick-fix",
+  "target_branch": "main",
+  "title": "Quick fix for login issue",
+  "description": "Single-commit fix",
+  "remove_source_branch": true,
+  "squash": true
+}
+```
+
+## Related Tools
+
+- [`update_merge_request`](./update_merge_request.md) — Update MR details
+- [`merge_merge_request`](./merge_merge_request.md) — Merge an MR
+- [`approve_merge_request`](./approve_merge_request.md) — Approve an MR
+- [`list_merge_requests`](./list_merge_requests.md) — List project MRs
+
+## Notes
+
+- Both branches must exist before creating MR
+- Source and target branch cannot be the same
+- Description supports full Markdown formatting
+- Squash combines all commits into one on merge
+- `remove_source_branch` auto-deletes branch after successful merge

--- a/docs/api/trigger_pipeline.md
+++ b/docs/api/trigger_pipeline.md
@@ -1,0 +1,76 @@
+# trigger_pipeline
+
+Trigger a new CI/CD pipeline for a specific branch or tag.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_id` | string | Yes | Project ID or path |
+| `ref` | string | Yes | Branch name, tag, or commit SHA |
+| `variables` | object | No | Pipeline variables as key-value pairs |
+
+## Response
+
+```json
+{
+  "id": 47,
+  "iid": 12,
+  "project_id": 1,
+  "status": "pending",
+  "ref": "main",
+  "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+  "web_url": "https://gitlab.com/my-org/my-project/-/pipelines/47",
+  "created_at": "2024-01-15T10:00:00.000Z",
+  "updated_at": "2024-01-15T10:00:00.000Z"
+}
+```
+
+## Example Usage
+
+### Basic Pipeline Trigger
+```json
+{
+  "project_id": "my-org/my-project",
+  "ref": "main"
+}
+```
+
+### Pipeline with Variables
+```json
+{
+  "project_id": "123",
+  "ref": "main",
+  "variables": {
+    "ENV": "staging",
+    "DEPLOY": "true",
+    "VERSION": "1.2.3"
+  }
+}
+```
+
+### Trigger on Specific Tag
+```json
+{
+  "project_id": "my-org/my-project",
+  "ref": "v1.0.0",
+  "variables": {
+    "RELEASE": "production"
+  }
+}
+```
+
+## Related Tools
+
+- [`list_pipelines`](./list_pipelines.md) — List project pipelines
+- [`get_pipeline`](./get_pipeline.md) — Get pipeline details
+- [`retry_pipeline`](./retry_pipeline.md) — Retry failed pipeline
+- [`cancel_pipeline`](./cancel_pipeline.md) — Cancel running pipeline
+
+## Notes
+
+- Ref can be branch name, tag, or commit SHA
+- Variables override pipeline defaults from `.gitlab-ci.yml`
+- Pipeline starts immediately (async operation)
+- Check pipeline status with `get_pipeline` tool
+- User must have permission to trigger pipelines


### PR DESCRIPTION
**Foundation for comprehensive API documentation.**

## What's Included

Three fully documented core tools:
1. **create_issue** — Create issues with parameters, response, examples
2. **create_merge_request** — Create MRs with related tools
3. **trigger_pipeline** — Trigger CI/CD with variables

## Format

Each doc includes:
- Parameter table (type, required, description)
- Complete response schema
- 2-3 real-world usage examples
- Related tools cross-references
- Implementation notes

## Next Steps

- Expand with 10-15 more core tools in Phase 2
- Build to all 86 tools in batches
- Deploy to static docs site (*.yoda.digital) when content-ready

Closes #16 (Phase 1)