### PR TITLE
chore: link to opensource.yoda.digital portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 </p>
 
 <p align="center">
+  <a href="https://opensource.yoda.digital/projects/mcp-gitlab-server/">
+    <img alt="Listed on Yoda Digital Open Source" src="https://img.shields.io/badge/listed%20on-opensource.yoda.digital-af9568?style=flat-square">
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/@yoda.digital/gitlab-mcp-server">
     <img alt="npm version" src="https://img.shields.io/npm/v/@yoda.digital/gitlab-mcp-server?color=blue">
   </a>

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
   "bugs": {
     "url": "https://github.com/yoda-digital/mcp-gitlab-server/issues"
   },
-  "homepage": "https://github.com/yoda-digital/mcp-gitlab-server#readme"
+  "homepage": "https://opensource.yoda.digital/projects/mcp-gitlab-server/"
 }


### PR DESCRIPTION
Adds a portal backlink to README + updates package.json `homepage` field to the project's page on https://opensource.yoda.digital. Pure metadata change — no source files touched.