### PR TITLE
docs: add SECURITY.md + CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to `@yoda.digital/gitlab-mcp-server` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+_Nothing yet. New entries land here between releases._
+
+## [0.3.1] - 2026-05-02
+
+### Fixed
+
+- `list_issues` silently dropped issue IIDs past the first page of results;
+  pagination now returns the full set across pages (#24).
+- Documentation: corrected `GITLAB_URL` references in README and
+  `CONTRIBUTING.md` — the actual environment variable is `GITLAB_API_URL`.
+
+### Security
+
+- Patched transitive npm vulnerabilities in `ajv`, `hono`, and `rollup`
+  reported by `npm audit`. No exploit known in this server's usage path,
+  but tracked dependencies must stay clean.
+
+### Changed
+
+- `.mcp.json` added to `.gitignore` so accidental client config files are
+  not committed.
+- README: named competitor table for clearer positioning; onboarding path
+  fixed (#21).
+- API reference documentation expanded for core tools (#20).
+- Removed marketing language; the README now reflects the 86 real MCP tools
+  the server actually exposes (#19).
+
+## [0.3.0] - earlier
+
+Prior history retained in git. From 0.3.1 onward, every release ships a
+matching CHANGELOG entry alongside the version bump.
+
+## Listed at
+
+[opensource.yoda.digital/projects/mcp-gitlab-server/](https://opensource.yoda.digital/projects/mcp-gitlab-server/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report security vulnerabilities **privately** via GitHub's
+[private vulnerability reporting](https://github.com/yoda-digital/mcp-gitlab-server/security/advisories/new),
+**not** through public issues.
+
+Expected response time: best-effort within 7 days. Coordinated disclosure
+preferred.
+
+## Scope
+
+This server connects to a GitLab instance using a personal access token
+or OAuth token supplied by the operator and exposes the GitLab API over MCP.
+The threat model includes:
+
+- **Token misuse / leak** — the access token has whatever scope the operator
+  grants it. Run with the minimum scopes you need (`read_api` for read-only
+  use; full `api` only when write tools are required). Never check tokens
+  into version control, log them, or paste them into bug reports.
+- **Read-only mode bypass** — the `READ_ONLY_MODE=true` flag must reject every
+  mutating call. A regression that lets a write tool execute under read-only
+  mode is a security bug — please report it.
+- **SSRF / endpoint forgery** — `GITLAB_API_URL` is operator-configurable.
+  Pointing it at an attacker-controlled host turns the server into an oracle
+  for the configured token. Validate the URL before deployment.
+- **Stream corruption** — when running over stdio, anything writing to
+  stdout outside the MCP protocol stream is a bug; reports of such regressions
+  are treated as security issues because they can desynchronize a client.
+- **Dependency CVEs** — high-severity transitive vulnerabilities reported by
+  `npm audit` or by Dependabot are addressed in the next patch release.
+
+## Out of scope
+
+- Vulnerabilities in your GitLab instance itself.
+- Issues that require local filesystem write access on the host running the
+  server.
+- The behavior of any third-party MCP client (Claude Desktop, Cursor, Zed,
+  VS Code) — those have their own security policies.
+
+## Public disclosure
+
+Once a fix is merged and a release is cut, we publish a CVE through GitHub
+Security Advisories where applicable.
+
+## Listed at
+
+[opensource.yoda.digital/projects/mcp-gitlab-server/](https://opensource.yoda.digital/projects/mcp-gitlab-server/)


### PR DESCRIPTION
Adds the two missing repo-hygiene files:

- **SECURITY.md** — private disclosure flow via GitHub Security Advisories, scope (token misuse, read-only bypass, SSRF, stream corruption, dep CVEs), out-of-scope list.
- **CHANGELOG.md** — Keep a Changelog 1.1.0 / SemVer. Backfilled the 0.3.1 entry from git history (#24, #21, #20, #19, ajv/hono/rollup CVE patches).

Both reference the [Yoda Digital open-source portal](https://opensource.yoda.digital/projects/mcp-gitlab-server/) page.