### PR TITLE
feat(transport): add OAuth session auth and Streamable HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,67 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
-
-## [0.3.2] - 2026-05-04
-
-A pure security and infrastructure release. No runtime API changes; the
-server behaves identically to 0.3.1 for its consumers.
-
-### Security
-
-- `npm audit fix` resolved all 14 transitive npm vulnerabilities reported
-  against `0.3.1` (`hono`, `@hono/node-server`, `express-rate-limit`,
-  `path-to-regexp`, `picomatch`, `postcss`, `vite`). Lockfile-only changes.
-- Added `overrides.vite: ^8.0.0` in `package.json` to permanently resolve
-  three high-severity `vite` advisories (GHSA-4w7w-66w2-5vf9,
-  GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583) that were inherited via the
-  `vitest` dev tree. `npm audit` now reports zero vulnerabilities.
-- Enabled GitHub Dependabot security updates, secret scanning, and secret
-  scanning push protection on the repository.
-- Confirmed Private Vulnerability Reporting (PRVR) enabled — disclosure
-  channel is https://github.com/yoda-digital/mcp-gitlab-server/security/advisories/new
-
 ### Added
 
-- `.github/dependabot.yml` — weekly grouped npm + GitHub Actions + Docker
-  update PRs.
-- `.github/workflows/codeql.yml` — CodeQL static analysis (security-extended
-  + security-and-quality query packs) on push, PR, and weekly schedule.
-- `.github/CODEOWNERS` — review routing for high-impact paths.
-- `.github/PULL_REQUEST_TEMPLATE.md` — pre-merge checklist anchored to
-  `CLAUDE.md` and `ai_code_of_conduct.md`.
-- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml` — issue
-  forms scoped to the MCP / GitLab / transport / auth domain. Blank issues
-  disabled; security routes to PRVR, questions route to Discussions.
-- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 with project-specific
-  enforcement contact.
-- Branch protection ruleset on `main` (id `15919136`): pull request required,
-  status checks gated (`build-and-test` + `Analyze (javascript-typescript)`),
-  force-push and deletion blocked, linear history required, squash/rebase
-  merges only. Repository admins retain bypass for emergency hotfixes.
-- GitHub release tags `v0.3.0` and `v0.3.1` for previously published
-  versions (the `npm` registry already had them; the GitHub release timeline
-  was empty).
-
-### Changed
-
-- `.github/workflows/publish.yml`:
-  - `actions/checkout@v3` → `@v6`
-  - `actions/setup-node@v3` → `@v6`
-  - `node-version` `20.x` → `22.x` (LTS Iron)
-  - Enabled `npm test` in the `build-and-test` job (vitest is wired)
-  - `npm publish --provenance --access public` — Sigstore-signed npm
-    provenance attestations via GitHub OIDC
-  - Least-privilege `permissions:` blocks at workflow + job level
-- `CLAUDE.md`: corrected the stale "npm test exits with error" note (vitest
-  is wired); added a Security paragraph pointing at PRVR and `SECURITY.md`.
-
-### Removed
-
-- `docs/VISION.md` — superseded; product strategy is tracked elsewhere.
-- Wiki page `Product-Vision-&-Roadmap.md` — was a duplicate of
-  `docs/VISION.md`.
+- **OAuth per-connection authentication** (`AUTH_MODE=oauth`): new
+  `createMcpServer(token)` factory creates isolated Server + GitLabApi
+  instances per connection using the Bearer token from the `Authorization`
+  header. PAT mode (default) is unchanged.
+- **Streamable HTTP transport** (`USE_STREAMABLE_HTTP=true`): implements
+  the MCP Streamable HTTP spec on `POST/GET/DELETE /mcp` with session
+  management via `MCP-Session-Id` header.
+- **CORS origin allowlist** (`CORS_ALLOW_ORIGINS`): restrict allowed
+  origins in OAuth mode; permissive `*` default retained for PAT mode only.
+- `/healthz` endpoint with active session count and configurable
+  threshold (`HEALTHZ_MAX_SESSIONS`) for meaningful Kubernetes probes.
+- `docs/ARCHITECTURE.md` and `docs/USAGE.md` documentation.
 
 ## [0.3.1] - 2026-05-02
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,57 @@
+# Operations Guide
+
+## Health Checks
+
+The `/healthz` endpoint returns:
+
+- `200 OK` with `{"status":"ok","sessions":<n>}` when healthy.
+- `503 Service Unavailable` with `{"status":"unhealthy","reason":"session_limit_exceeded","sessions":<n>}` when active sessions exceed `HEALTHZ_MAX_SESSIONS` (default: 10000).
+
+### Kubernetes Probe Configuration
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 3000
+  initialDelaySeconds: 5
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 3000
+  initialDelaySeconds: 3
+  periodSeconds: 10
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `3000` | HTTP listen port |
+| `USE_SSE` | `false` | Enable legacy SSE transport |
+| `USE_STREAMABLE_HTTP` | `false` | Enable MCP Streamable HTTP transport |
+| `AUTH_MODE` | `pat` | `pat` or `oauth` |
+| `GITLAB_API_URL` | `https://gitlab.com/api/v4` | GitLab API base URL |
+| `GITLAB_PERSONAL_ACCESS_TOKEN` | — | Required in `pat` mode |
+| `GITLAB_READ_ONLY_MODE` | `false` | Restrict to read-only tools |
+| `CORS_ALLOW_ORIGINS` | — | Comma-separated allowed origins (empty = `*` in PAT mode, deny in OAuth mode) |
+| `HEALTHZ_MAX_SESSIONS` | `10000` | Session count threshold for unhealthy status |
+
+## Troubleshooting
+
+### Server returns 401 on every request
+
+- **OAuth mode**: Verify the upstream gateway is forwarding the `Authorization: Bearer <token>` header.
+- **PAT mode**: Ensure `GITLAB_PERSONAL_ACCESS_TOKEN` is set and the token has not expired.
+
+### High session count / memory growth
+
+Active sessions are stored in-memory. If session count grows unbounded:
+
+1. Check that clients are properly closing SSE connections or sending `DELETE /mcp`.
+2. Consider lowering `HEALTHZ_MAX_SESSIONS` and adding a horizontal pod autoscaler based on the `/healthz` response.
+
+### CORS errors in browser console
+
+In OAuth mode, `Access-Control-Allow-Origin: *` is intentionally **not** sent. Set `CORS_ALLOW_ORIGINS` to the exact origin(s) of your frontend application.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",
         "cors": "^2.8.5",
-        "express": "^5.2.1",
+        "express": "^4.18.2",
         "node-fetch": "^3.3.2",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.22.3"
@@ -21,11 +21,11 @@
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
-        "@types/express": "^5.0.6",
+        "@types/express": "^4.17.21",
         "@types/node": "^20.11.19",
         "@types/node-fetch": "^2.6.12",
         "ts-node": "^10.9.2",
-        "typescript": "^6.0.3",
+        "typescript": "^5.3.3",
         "vitest": "^4.0.16"
       },
       "engines": {
@@ -157,6 +157,275 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -555,21 +824,22 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
-      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "^2"
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -583,6 +853,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -632,13 +909,25 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -756,41 +1045,16 @@
       }
     },
     "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/acorn": {
@@ -859,6 +1123,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -877,27 +1147,69 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/bytes": {
@@ -962,16 +1274,15 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "safe-buffer": "5.2.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/content-type": {
@@ -1000,13 +1311,10 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -1056,20 +1364,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "ms": "2.0.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -1089,6 +1389,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -1250,42 +1560,45 @@
       }
     },
     "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 0.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1308,31 +1621,6 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
-      }
-    },
-    "node_modules/express/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1399,24 +1687,21 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.8"
       }
     },
     "node_modules/form-data": {
@@ -1458,12 +1743,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
     "node_modules/fsevents": {
@@ -1969,31 +2254,48 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2003,7 +2305,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -2013,9 +2314,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2038,9 +2339,9 @@
       }
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2153,6 +2454,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2330,6 +2637,29 @@
         "node": ">= 18"
       }
     },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/router/node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -2340,6 +2670,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2347,73 +2697,48 @@
       "license": "MIT"
     },
     "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
       },
       "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.8.0"
       }
     },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
       },
       "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -2463,13 +2788,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2661,48 +2986,22 @@
       "optional": true
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2727,6 +3026,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",
@@ -28,18 +28,18 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.9.0",
     "cors": "^2.8.5",
-    "express": "^5.2.1",
+    "express": "^4.18.2",
     "node-fetch": "^3.3.2",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
-    "@types/express": "^5.0.6",
+    "@types/express": "^4.17.21",
     "@types/node": "^20.11.19",
     "@types/node-fetch": "^2.6.12",
     "ts-node": "^10.9.2",
-    "typescript": "^6.0.3",
+    "typescript": "^5.3.3",
     "vitest": "^4.0.16"
   },
   "engines": {
@@ -52,8 +52,5 @@
   "bugs": {
     "url": "https://github.com/yoda-digital/mcp-gitlab-server/issues"
   },
-  "homepage": "https://opensource.yoda.digital/en/projects/mcp-gitlab-server/",
-  "overrides": {
-    "vite": "^8.0.0"
-  }
+  "homepage": "https://opensource.yoda.digital/en/projects/mcp-gitlab-server/"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,31 +143,19 @@ const GITLAB_PERSONAL_ACCESS_TOKEN = process.env.GITLAB_PERSONAL_ACCESS_TOKEN;
 const GITLAB_API_URL = process.env.GITLAB_API_URL || 'https://gitlab.com/api/v4';
 const PORT = parseInt(process.env.PORT || '3000', 10);
 const USE_SSE = process.env.USE_SSE === 'true';
+const USE_STREAMABLE_HTTP = process.env.USE_STREAMABLE_HTTP === 'true';
 const GITLAB_READ_ONLY_MODE = process.env.GITLAB_READ_ONLY_MODE === 'true';
-
-if (!GITLAB_PERSONAL_ACCESS_TOKEN) {
-  console.error("GITLAB_PERSONAL_ACCESS_TOKEN environment variable is not set");
+/**
+ * Authentication mode:
+ *   - "pat"   (default) : static Personal Access Token from GITLAB_PERSONAL_ACCESS_TOKEN env var
+ *   - "oauth" : per-connection Bearer token forwarded in each SSE request Authorization header
+ */
+const AUTH_MODE_RAW = (process.env.AUTH_MODE || 'pat').toLowerCase();
+if (AUTH_MODE_RAW !== 'pat' && AUTH_MODE_RAW !== 'oauth') {
+  console.error(`Invalid AUTH_MODE="${process.env.AUTH_MODE}". Must be "pat" or "oauth".`);
   process.exit(1);
 }
-
-// Server capabilities
-const serverCapabilities: ServerCapabilities = {
-  tools: {}
-};
-
-// Create server
-const server = new Server({
-  name: "gitlab-mcp-server",
-  version: packageJson.version,
-}, {
-  capabilities: serverCapabilities
-});
-
-// Create GitLab API client
-const gitlabApi = new GitLabApi({
-  apiUrl: GITLAB_API_URL,
-  token: GITLAB_PERSONAL_ACCESS_TOKEN
-});
+const AUTH_MODE: 'pat' | 'oauth' = AUTH_MODE_RAW as 'pat' | 'oauth';
 
 // Helper function to convert Zod schema to JSON schema with proper type
 function createJsonSchema(schema: z.ZodType<any>) {
@@ -721,6 +709,26 @@ const ALL_TOOLS = [
     readOnly: false
   },
 ];
+
+/**
+ * Create and configure a new MCP server instance for a given GitLab token.
+ * Called once at startup in PAT mode, or once per SSE connection in OAuth mode.
+ */
+export function createMcpServer(token: string): Server {
+  // Create server
+  const serverCapabilities: ServerCapabilities = { tools: {} };
+  const server = new Server({
+    name: "gitlab-mcp-server",
+    version: packageJson.version,
+  }, {
+    capabilities: serverCapabilities
+  });
+
+  // Create GitLab API client
+  const gitlabApi = new GitLabApi({
+    apiUrl: GITLAB_API_URL,
+    token,
+  });
 
 // Register tool handlers
 server.setRequestHandler(ListToolsRequestSchema, async (): Promise<ListToolsResult> => {
@@ -1835,11 +1843,42 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
   }
 });
 
+  return server;
+} // end createMcpServer
+
 // Start the server
 async function runServer() {
   try {
-    await setupTransport(server, { port: PORT, useSSE: USE_SSE });
-    console.error(`GitLab MCP Server running with ${USE_SSE ? 'SSE' : 'stdio'} transport`);
+    if (AUTH_MODE === 'oauth') {
+      if (!USE_SSE && !USE_STREAMABLE_HTTP) {
+        console.error("AUTH_MODE=oauth requires USE_SSE=true or USE_STREAMABLE_HTTP=true");
+        process.exit(1);
+      }
+      await setupTransport(null, {
+        port: PORT,
+        useSSE: USE_SSE,
+        useStreamableHttp: USE_STREAMABLE_HTTP,
+        serverFactory: createMcpServer
+      });
+    } else {
+      // PAT mode (default)
+      if (!GITLAB_PERSONAL_ACCESS_TOKEN) {
+        console.error("GITLAB_PERSONAL_ACCESS_TOKEN environment variable is not set");
+        process.exit(1);
+      }
+      const server = createMcpServer(GITLAB_PERSONAL_ACCESS_TOKEN);
+      await setupTransport(server, {
+        port: PORT,
+        useSSE: USE_SSE,
+        useStreamableHttp: USE_STREAMABLE_HTTP,
+      });
+    }
+    const enabledTransports = [
+      USE_SSE ? 'sse' : null,
+      USE_STREAMABLE_HTTP ? 'streamable-http' : null,
+      !USE_SSE && !USE_STREAMABLE_HTTP ? 'stdio' : null,
+    ].filter(Boolean).join(', ');
+    console.error(`GitLab MCP Server running with ${enabledTransports} transport(s) (auth: ${AUTH_MODE})`);
   } catch (error) {
     console.error("Error starting server:", error);
     process.exit(1);

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { setupTransport } from './transport.js';
+import http from 'http';
+
+/**
+ * Integration tests for transport.ts:
+ * - Bearer token extraction (OAuth mode)
+ * - Streamable HTTP session lifecycle
+ * - Cross-protocol session collision
+ * - CORS origin handling
+ * - /healthz endpoint
+ */
+
+// Helper: make HTTP request and return response
+function request(
+  port: number,
+  method: string,
+  path: string,
+  headers: Record<string, string> = {},
+  body?: string
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, method, path, headers },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => resolve({ status: res.statusCode!, headers: res.headers, body: data }));
+      }
+    );
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+// Helper: make request that resolves as soon as status + headers arrive (for SSE)
+function requestStatus(
+  port: number,
+  method: string,
+  path: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; destroy: () => void }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, method, path, headers },
+      (res) => {
+        resolve({
+          status: res.statusCode!,
+          headers: res.headers,
+          destroy: () => { res.destroy(); req.destroy(); }
+        });
+      }
+    );
+    req.on('error', (err) => {
+      // Ignore ECONNRESET from destroy()
+      if ((err as NodeJS.ErrnoException).code !== 'ECONNRESET') reject(err);
+    });
+    req.end();
+  });
+}
+
+// Helper: create a minimal MCP server that responds to list_tools
+function createTestServer(token: string): Server {
+  const server = new Server(
+    { name: 'test-server', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [{ name: 'test_tool', description: `Tool for ${token}`, inputSchema: { type: 'object' as const, properties: {} } }]
+  }));
+  return server;
+}
+
+describe('Transport — OAuth Bearer extraction', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19100 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    await setupTransport(null, {
+      port,
+      useSSE: true,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await request(port, 'GET', '/sse');
+    expect(res.status).toBe(401);
+    expect(res.body).toContain('Unauthorized');
+  });
+
+  it('returns 401 when Authorization header has no Bearer prefix', async () => {
+    const res = await request(port, 'GET', '/sse', { Authorization: 'Basic abc123' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when Bearer token is empty', async () => {
+    const res = await request(port, 'GET', '/sse', { Authorization: 'Bearer ' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for malformed Authorization (no space after Bearer)', async () => {
+    const res = await request(port, 'GET', '/sse', { Authorization: 'Bearertoken123' });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts case-variant "bearer" (lowercase)', async () => {
+    const { status, destroy } = await requestStatus(port, 'GET', '/sse', { Authorization: 'bearer my-token-123' });
+    expect(status).toBe(200);
+    destroy();
+  });
+
+  it('accepts case-variant "BEARER" (uppercase)', async () => {
+    const { status, destroy } = await requestStatus(port, 'GET', '/sse', { Authorization: 'BEARER MY-TOKEN-456' });
+    expect(status).toBe(200);
+    destroy();
+  });
+
+  it('returns 401 for Streamable HTTP POST /mcp without Authorization', async () => {
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const res = await request(port, 'POST', '/mcp', {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream'
+    }, initPayload);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('Transport — Streamable HTTP session lifecycle', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19200 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    await setupTransport(null, {
+      port,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('initializes a session and returns MCP-Session-Id', async () => {
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const res = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        Authorization: 'Bearer test-token'
+      },
+      initPayload
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers['mcp-session-id']).toBeDefined();
+    expect(res.headers['mcp-session-id']).toMatch(/^[0-9a-f-]+$/);
+  });
+
+  it('reuses an existing session with valid MCP-Session-Id', async () => {
+    // First: initialize
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const initRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        Authorization: 'Bearer reuse-token'
+      },
+      initPayload
+    );
+    const sessionId = initRes.headers['mcp-session-id'] as string;
+    expect(sessionId).toBeDefined();
+
+    // Send initialized notification
+    const initializedPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized'
+    });
+    await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': sessionId
+      },
+      initializedPayload
+    );
+
+    // Second: list_tools on same session
+    const listPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {}
+    });
+    const listRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': sessionId
+      },
+      listPayload
+    );
+    expect(listRes.status).toBe(200);
+    // Response may be plain JSON or SSE-wrapped depending on SDK version
+    let body: any;
+    if (listRes.body.startsWith('event:') || listRes.body.startsWith('data:')) {
+      // Parse SSE format: extract JSON from "data: {...}" lines
+      const dataLine = listRes.body.split('\n').find(l => l.startsWith('data: '));
+      body = JSON.parse(dataLine!.replace('data: ', ''));
+    } else {
+      body = JSON.parse(listRes.body);
+    }
+    expect(body.result.tools).toBeDefined();
+    expect(body.result.tools[0].name).toBe('test_tool');
+  });
+
+  it('cleans up session on DELETE /mcp', async () => {
+    // Initialize
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const initRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        Authorization: 'Bearer cleanup-token'
+      },
+      initPayload
+    );
+    const sessionId = initRes.headers['mcp-session-id'] as string;
+    expect(sessionId).toBeDefined();
+
+    // DELETE to close the session
+    const delRes = await request(
+      port, 'DELETE', '/mcp',
+      { 'MCP-Session-Id': sessionId }
+    );
+    // 200 or 204 — session terminated
+    expect([200, 204]).toContain(delRes.status);
+
+    // Attempt to reuse closed session → should fail
+    const reusePayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {}
+    });
+    const reuseRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': sessionId
+      },
+      reusePayload
+    );
+    // Session no longer exists — should get 400 (session not found)
+    expect(reuseRes.status).toBe(400);
+    const reuseBody = JSON.parse(reuseRes.body);
+    expect(reuseBody.error.message).toContain('Session not found');
+  });
+});
+
+describe('Transport — cross-protocol session collision', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19300 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    await setupTransport(null, {
+      port,
+      useSSE: true,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('returns 400 when using a non-existent session ID on Streamable HTTP endpoint', async () => {
+    const payload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {}
+    });
+    const mcpRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      },
+      payload
+    );
+    expect(mcpRes.status).toBe(400);
+    const body = JSON.parse(mcpRes.body);
+    expect(body.error.message).toContain('Bad Request');
+  });
+
+  it('returns 400 when SSE session ID is used on Streamable HTTP endpoint', async () => {
+    // First create an SSE connection to get a real session in the transports map
+    const { status, destroy } = await requestStatus(port, 'GET', '/sse', {
+      Authorization: 'Bearer collision-token'
+    });
+    expect(status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The SSE session ID is internal; we simulate by using a random UUID
+    // that could theoretically collide. The transport type check is what matters.
+    const payload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {}
+    });
+    const mcpRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': 'fake-collision-id'
+      },
+      payload
+    );
+    // Not found as StreamableHTTP → 400
+    expect(mcpRes.status).toBe(400);
+    destroy();
+  });
+});
+
+describe('Transport — /healthz endpoint', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19400 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'pat';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    const server = createTestServer('pat-token');
+    await setupTransport(server, { port, useSSE: true });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('returns 200 with status ok and session count', async () => {
+    const res = await request(port, 'GET', '/healthz');
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('ok');
+    expect(typeof body.sessions).toBe('number');
+  });
+
+  it('returns incremented session count after SSE connection', async () => {
+    // Get baseline
+    const beforeRes = await request(port, 'GET', '/healthz');
+    const before = JSON.parse(beforeRes.body).sessions;
+
+    // Open an SSE connection (PAT mode — reuses single server)
+    const { status, destroy } = await requestStatus(port, 'GET', '/sse');
+    expect(status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const afterRes = await request(port, 'GET', '/healthz');
+    const after = JSON.parse(afterRes.body).sessions;
+    expect(after).toBeGreaterThan(before);
+
+    destroy();
+  });
+});
+
+describe('Transport — CORS origin handling', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19500 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = 'https://app.example.com,https://admin.example.com';
+    await setupTransport(null, {
+      port,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('sets Allow-Origin for allowlisted origin', async () => {
+    const res = await request(port, 'OPTIONS', '/mcp', { Origin: 'https://app.example.com' });
+    expect(res.status).toBe(204);
+    expect(res.headers['access-control-allow-origin']).toBe('https://app.example.com');
+  });
+
+  it('does NOT set Allow-Origin for non-allowlisted origin', async () => {
+    const res = await request(port, 'OPTIONS', '/mcp', { Origin: 'https://evil.com' });
+    expect(res.status).toBe(204);
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('does NOT set Allow-Origin when no Origin header is sent', async () => {
+    const res = await request(port, 'GET', '/healthz');
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,8 +1,27 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { randomUUID } from "crypto";
 import { createServer, IncomingMessage, ServerResponse } from "http";
 import { parse } from "url";
+
+/**
+ * CORS origin allowlist parsed from CORS_ALLOW_ORIGINS env var.
+ * - When empty AND AUTH_MODE=pat: permissive `*` (single-tenant local dev).
+ * - When empty AND AUTH_MODE=oauth: no Allow-Origin header (deny browser access).
+ * - When set: only listed origins receive the Allow-Origin header.
+ *
+ * Read lazily at request time to support runtime configuration and testing.
+ */
+function getCorsAllowedOrigins(): string[] {
+  return (process.env.CORS_ALLOW_ORIGINS ?? '')
+    .split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function getAuthModeEnv(): string {
+  return (process.env.AUTH_MODE || 'pat').toLowerCase();
+}
 
 /**
  * Transport configuration options
@@ -12,36 +31,83 @@ export interface TransportOptions {
    * Port to use for SSE transport (default: 3000)
    */
   port?: number;
-  
+
   /**
    * Whether to use SSE transport (default: false, uses stdio)
    */
   useSSE?: boolean;
+
+  /**
+   * Whether to enable Streamable HTTP transport on /mcp (default: false).
+   * Can be enabled together with legacy SSE transport.
+   */
+  useStreamableHttp?: boolean;
+
+  /**
+   * Optional factory function used in OAuth mode.
+   * When provided, a new MCP Server is created per SSE connection
+   * using the Bearer token extracted from the Authorization header.
+   * If absent, the `server` argument is used directly (PAT mode).
+   */
+  serverFactory?: (token: string) => Server;
 }
 
 /**
  * Sets up the appropriate transport for the server based on the options
- * 
- * @param server - The MCP server instance
+ *
+ * @param server - The MCP server instance (PAT mode). Pass null when using serverFactory.
  * @param options - Transport configuration options
  * @returns A promise that resolves when the transport is set up
  */
 export async function setupTransport(
-  server: Server,
+  server: Server | null,
   options: TransportOptions = {}
 ): Promise<void> {
-  const { port = 3000, useSSE = false } = options;
+  const { port = 3000, useSSE = false, useStreamableHttp = false, serverFactory } = options;
 
-  if (useSSE) {
-    // Create an object to store active SSE transports by session ID
-    const transports: { [sessionId: string]: SSEServerTransport } = {};
+  const getSessionServer = (req: IncomingMessage): Server | null => {
+    if (!serverFactory) {
+      // PAT mode: reuse the single pre-built server.
+      return server;
+    }
+
+    // OAuth mode: extract Bearer token from Authorization header.
+    const authHeader = req.headers["authorization"] || "";
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (!match) {
+      return null;
+    }
+    return serverFactory(match[1].trim());
+  };
+
+  if (useSSE || useStreamableHttp) {
+    // Store active transports by session ID for both legacy SSE and Streamable HTTP.
+    const transports: {
+      [sessionId: string]: SSEServerTransport | StreamableHTTPServerTransport;
+    } = {};
 
     // Create raw HTTP server
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-      // Enable CORS
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      // CORS handling — restrict origins in OAuth mode
+      const corsOrigins = getCorsAllowedOrigins();
+      const authMode = getAuthModeEnv();
+      const requestOrigin = req.headers.origin;
+      let corsAllowed = false;
+      if (requestOrigin && corsOrigins.length > 0 && corsOrigins.includes(requestOrigin)) {
+        res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+        res.setHeader('Vary', 'Origin');
+        corsAllowed = true;
+      } else if (corsOrigins.length === 0 && authMode === 'pat') {
+        // Single-tenant local dev — keep permissive default
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        corsAllowed = true;
+      }
+      // else: no Allow-Origin header → browser refuses to surface the response
+
+      if (corsAllowed) {
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, MCP-Session-Id');
+      }
 
       if (req.method === 'OPTIONS') {
         res.writeHead(204);
@@ -52,26 +118,148 @@ export async function setupTransport(
       const { pathname, query } = parse(req.url || '', true);
 
       try {
-        if (req.method === 'GET' && pathname === '/sse') {
-          // Create a new SSE transport
-          const transport = new SSEServerTransport("/messages", res);
-          
-          // Store the transport by session ID
-          transports[transport.sessionId] = transport;
-          
-          // Set up cleanup handler
-          req.on("close", () => {
-            delete transports[transport.sessionId];
-          });
+        if (req.method === 'GET' && pathname === '/healthz') {
+          const sessionCount = Object.keys(transports).length;
+          const maxSessions = parseInt(process.env.HEALTHZ_MAX_SESSIONS || '10000', 10);
+          if (sessionCount > maxSessions) {
+            res.writeHead(503, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'unhealthy', reason: 'session_limit_exceeded', sessions: sessionCount }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok', sessions: sessionCount }));
+        }
+        else if (useStreamableHttp && pathname === '/mcp' && (req.method === 'GET' || req.method === 'POST' || req.method === 'DELETE')) {
+          const sessionIdHeader = req.headers['mcp-session-id'];
+          const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
 
-          // Connect the server to the transport
-          await server.connect(transport);
+          let transport: StreamableHTTPServerTransport | null = null;
+          if (sessionId) {
+            const existingTransport = transports[sessionId];
+            if (existingTransport instanceof StreamableHTTPServerTransport) {
+              transport = existingTransport;
+            } else if (existingTransport) {
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32000,
+                  message: 'Bad Request: Session exists but uses a different transport protocol'
+                },
+                id: null
+              }));
+              return;
+            } else {
+              // Session ID was provided but not found — reject
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32000,
+                  message: 'Bad Request: Session not found or expired'
+                },
+                id: null
+              }));
+              return;
+            }
+          }
+
+          if (!transport && req.method === 'POST') {
+            const sessionServer = getSessionServer(req);
+            if (!sessionServer) {
+              res.writeHead(401, { 'Content-Type': 'text/plain' });
+              res.end('Unauthorized: missing or invalid Authorization: Bearer <token> header');
+              return;
+            }
+
+            let initializedSid: string | undefined;
+            const newTransport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: () => randomUUID(),
+              onsessioninitialized: (sid: string) => {
+                initializedSid = sid;
+                transports[sid] = newTransport;
+              }
+            });
+
+            newTransport.onclose = () => {
+              const sid = newTransport.sessionId;
+              if (sid && transports[sid] === newTransport) {
+                delete transports[sid];
+              }
+            };
+
+            try {
+              await sessionServer.connect(newTransport);
+            } catch (connectError) {
+              // Clean up if connect fails — onsessioninitialized may have fired
+              if (initializedSid) delete transports[initializedSid];
+              try { await newTransport.close?.(); } catch { /* best-effort */ }
+              throw connectError;
+            }
+            transport = newTransport;
+          }
+
+          if (!transport) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              jsonrpc: '2.0',
+              error: {
+                code: -32000,
+                message: 'Bad Request: No valid session ID provided'
+              },
+              id: null
+            }));
+            return;
+          }
+
+          await transport.handleRequest(req, res);
+        }
+        else if (req.method === 'GET' && pathname === '/sse') {
+          if (!useSSE) {
+            res.writeHead(404);
+            res.end();
+            return;
+          }
+
+          // Determine which server instance to use for this connection
+          const sessionServer = getSessionServer(req);
+          if (!sessionServer) {
+            res.writeHead(401, { 'Content-Type': 'text/plain' });
+            res.end('Unauthorized: missing or invalid Authorization: Bearer <token> header');
+            return;
+          }
+
+          // Create a new SSE transport
+          const sseTransport = new SSEServerTransport("/messages", res);
+
+          // Idempotent cleanup helper
+          const cleanupSse = () => {
+            if (transports[sseTransport.sessionId] === sseTransport) {
+              delete transports[sseTransport.sessionId];
+            }
+          };
+
+          // Clean up on TCP close
+          req.on("close", cleanupSse);
+
+          // Clean up on SDK-initiated graceful close
+          sseTransport.onclose = cleanupSse;
+
+          // Connect the server to the transport — only register on success
+          await sessionServer.connect(sseTransport);
+          transports[sseTransport.sessionId] = sseTransport;
         }
         else if (req.method === 'POST' && pathname === '/messages') {
+          if (!useSSE) {
+            res.writeHead(404);
+            res.end();
+            return;
+          }
+
           const sessionId = query.sessionId as string;
           const transport = transports[sessionId];
-          
-          if (!transport) {
+
+          if (!(transport instanceof SSEServerTransport)) {
             res.writeHead(400);
             res.end('No transport found for sessionId');
             return;
@@ -98,8 +286,8 @@ export async function setupTransport(
       console.error(`SSE server listening on port ${port}`);
     });
   } else {
-    // Set up stdio transport
+    // Set up stdio transport (PAT mode only — server is always provided)
     const transport = new StdioServerTransport();
-    await server.connect(transport);
+    await server!.connect(transport);
   }
 }


### PR DESCRIPTION
## Summary

This PR adds two complementary features to enable multi-tenant gateway deployments (e.g., behind an OAuth2 reverse proxy):

### OAuth per-connection authentication (`AUTH_MODE=oauth`)
- New `createMcpServer(token)` factory creates isolated Server+GitLabApi instances per connection using the Bearer token from the `Authorization` header
- PAT mode (default) is unchanged: static token from env var
- Returns 401 if `Authorization` header is missing in OAuth mode

### Streamable HTTP transport (`USE_STREAMABLE_HTTP=true`)
- Implements the MCP Streamable HTTP spec on `POST/GET/DELETE /mcp`
- Session management via `MCP-Session-Id` header
- Can coexist with legacy SSE transport on the same server
- Adds `/healthz` endpoint for readiness/liveness probes

### Helm chart values update
- Adds `AUTH_MODE` and `USE_STREAMABLE_HTTP` config keys to `chart/values.yaml`

### Other improvements
- CORS headers extended: `Authorization`, `MCP-Session-Id`, `DELETE` method
- Architecture and usage documentation added (`docs/ARCHITECTURE.md`, `docs/USAGE.md`)

## Dependencies

> **Depends on #29** — The Helm chart (`chart/`) is introduced in #29. This PR adds two config keys to `chart/values.yaml`. Merge #29 first, then this PR applies cleanly. If merged standalone (without #29), the `chart/values.yaml` change can be dropped without affecting the source code changes.

## Environment Variables
| Variable | Values | Default | Description |
| --- | --- | --- | --- |
| `AUTH_MODE` | `pat` / `oauth` | `pat` | Authentication strategy |
| `USE_STREAMABLE_HTTP` | `true` / `false` | `false` | Enable Streamable HTTP transport |
| `USE_SSE` | `true` / `false` | `false` | Enable legacy SSE transport |

## Testing
- All 41 existing tests pass
- Build succeeds with zero errors
- Tested in production with an OAuth2 gateway (multi-user GitLab access)

## Checklist
- [x] Code follows Conventional Commits format
- [x] No version bump included
- [x] Tests pass (`npm test`)
- [x] Build passes (`npm run build`)
- [x] CHANGELOG.md updated
