### PR TITLE
feat: add Dockerfile, Helm chart, and CI/CD workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+npm-debug.log
+.git
+.github
+chart
+*.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,139 @@
+name: "Build & Publish"
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}  # yoda-digital/mcp-gitlab-server
+  CHART_NAME: gitlab-mcp
+
+permissions:
+  contents: read
+  packages: write
+
+# -------------------------------------------------------------------
+# Job 1 — Validate (runs on every push and PR)
+# -------------------------------------------------------------------
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Helm lint
+        run: |
+          helm lint chart/ \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=dummy-for-lint
+
+      - name: Helm template smoke test
+        run: |
+          helm template test-release chart/ \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=dummy-for-lint \
+            > /dev/null
+
+  # -------------------------------------------------------------------
+  # Job 2 — Docker build + push (skipped on PRs)
+  # -------------------------------------------------------------------
+  docker:
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name != 'pull_request'
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # On tag push: v1.2.3 -> 1.2.3 + latest
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            # On main push (no tag): sha-<short>
+            type=sha,prefix=,enable=${{ github.ref_type != 'tag' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # -------------------------------------------------------------------
+  # Job 3 — Helm package + push (only on tags)
+  # -------------------------------------------------------------------
+  helm:
+    runs-on: ubuntu-latest
+    needs: docker
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Log in to ghcr.io (Helm OCI)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Compute version
+        id: version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update appVersion in Chart.yaml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          yq -i ".appVersion = \"$VERSION\"" chart/Chart.yaml
+          # Verify mutation
+          ACTUAL=$(yq '.appVersion' chart/Chart.yaml)
+          if [[ "$ACTUAL" != "$VERSION" ]]; then
+            echo "::error::appVersion mismatch: expected $VERSION, got $ACTUAL"
+            exit 1
+          fi
+
+      - name: Package chart
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          helm package chart/ \
+            --version "$VERSION" \
+            --destination .helm-pkg/
+
+      - name: Push chart to ghcr.io
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          helm push ".helm-pkg/${{ env.CHART_NAME }}-${VERSION}.tgz" \
+            oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Added
+
+- **Dockerfile** — multi-stage production build (`node:24-alpine`), non-root
+  user, read-only rootfs, security-context hardened.
+- **Helm chart** (`chart/`) — Kubernetes-ready deployment with ConfigMap,
+  Secret, ServiceAccount, PodDisruptionBudget, liveness/readiness probes
+  against `/healthz`, and support for `existingSecret`.
+  - Fail-loud guards: empty PAT token without `existingSecret` renders a
+    template error; PDB `minAvailable >= replicaCount` is caught at render
+    time to prevent drain deadlocks.
+  - New config values: `AUTH_MODE`, `USE_STREAMABLE_HTTP`,
+    `CORS_ALLOW_ORIGINS`, `HEALTHZ_MAX_SESSIONS` (from v0.4.0 features).
+- **GitHub Actions CI** (`.github/workflows/build.yml`) — three-job
+  pipeline: _validate_ (hadolint + helm lint + helm template), _docker_
+  (build & push via `docker/metadata-action`), _helm_ (package with
+  `--version` + OCI push). `:latest` tag only on semver releases; PRs run
+  validation only.
+- **`chart/values.schema.json`** — JSON Schema for native `helm lint`
+  validation of values.
+- **`chart/README.md`** — full values reference and install examples.
+- **README.md** — "Deploy to Kubernetes" section with Helm install examples.
 
 ## [0.4.0] - 2026-05-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------------------------
+# GitLab MCP Server — Production Dockerfile
+# Multi-stage build for a minimal runtime image.
+# ---------------------------------------------------------------------------
+
+# -- Stage 1: build ----------------------------------------------------------
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+# Build TypeScript sources
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+
+# -- Stage 2: runtime --------------------------------------------------------
+FROM node:24-alpine
+
+WORKDIR /app
+
+# Install only production dependencies in runtime image
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+
+# Copy compiled server
+COPY --from=builder /app/dist ./dist
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    USE_SSE=true
+
+EXPOSE 3000
+
+# Run as non-root using built-in node user (uid 1000)
+RUN chown -R node:node /app
+USER node
+
+ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -153,6 +153,35 @@ See our [Cursor Integration Guide](./docs/CURSOR_INTEGRATION.md) for step-by-ste
 
 ---
 
+## 🐳 Deploy to Kubernetes
+
+A production-ready Helm chart is included in [`chart/`](./chart/).
+
+```bash
+# Install from OCI registry
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set secret.GITLAB_PERSONAL_ACCESS_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
+
+# Or with an existing Secret
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set existingSecret=my-gitlab-secret
+
+# Or in OAuth mode (per-connection tokens)
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set config.AUTH_MODE=oauth \
+  --set config.CORS_ALLOW_ORIGINS="https://my-app.example.com"
+```
+
+The chart includes:
+- Fail-loud guards (empty token, PDB deadlock detection)
+- Liveness/readiness probes against `/healthz`
+- `values.schema.json` for native Helm validation
+- Support for all v0.4.0 features (OAuth, Streamable HTTP, CORS, session limits)
+
+See [`chart/README.md`](./chart/README.md) for full values reference.
+
+---
+
 ## 🎯 Use Cases
 
 - **AI-Assisted Development** — Let AI create MRs, manage issues, trigger CI/CD

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: gitlab-mcp
+description: Helm chart for the GitLab MCP Server
+type: application
+version: 0.1.0
+appVersion: "0.4.0"
+
+keywords:
+  - mcp
+  - gitlab
+  - devops
+
+home: https://github.com/yoda-digital/mcp-gitlab-server
+
+maintainers:
+  - name: Yoda Digital
+    url: https://github.com/yoda-digital

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,82 @@
+# gitlab-mcp
+
+A Helm chart for the GitLab MCP Server — provides GitLab integration
+via the Model Context Protocol (MCP) over SSE or Streamable HTTP.
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Helm 3.12+
+
+## Installing the chart
+
+```bash
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set secret.GITLAB_PERSONAL_ACCESS_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
+```
+
+### Using an existing Secret
+
+```bash
+kubectl create secret generic gitlab-mcp-token \
+  --from-literal=GITLAB_PERSONAL_ACCESS_TOKEN="glpat-xxxx"
+
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set existingSecret=gitlab-mcp-token
+```
+
+### OAuth mode (per-connection tokens)
+
+```bash
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set config.AUTH_MODE=oauth \
+  --set config.CORS_ALLOW_ORIGINS="https://my-app.example.com"
+```
+
+## Values
+
+| Key | Type | Default | Description |
+| ----- | ------ | --------- | ------------- |
+| `replicaCount` | int | `1` | Number of replicas. Multi-replica requires sticky sessions. |
+| `image.repository` | string | `ghcr.io/yoda-digital/mcp-gitlab-server` | Container image repository |
+| `image.tag` | string | `"latest"` | Image tag (overridden by CI) |
+| `image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
+| `config.PORT` | string | `"3000"` | Server listen port |
+| `config.USE_SSE` | string | `"true"` | Enable SSE transport |
+| `config.USE_STREAMABLE_HTTP` | string | `"false"` | Enable Streamable HTTP transport |
+| `config.GITLAB_API_URL` | string | `"https://gitlab.com/api/v4"` | GitLab API base URL |
+| `config.GITLAB_READ_ONLY_MODE` | string | `"false"` | Restrict to read-only tools |
+| `config.AUTH_MODE` | string | `"pat"` | Authentication mode: `pat` or `oauth` |
+| `config.CORS_ALLOW_ORIGINS` | string | `""` | Comma-separated allowed CORS origins |
+| `config.HEALTHZ_MAX_SESSIONS` | string | `"10000"` | Max sessions before /healthz returns 503 |
+| `secret.GITLAB_PERSONAL_ACCESS_TOKEN` | string | `""` | GitLab PAT (required in `pat` mode) |
+| `existingSecret` | string | `""` | Use an existing Secret instead of creating one |
+| `service.type` | string | `ClusterIP` | Kubernetes Service type |
+| `service.port` | int | `3000` | Service port |
+| `resources.requests.cpu` | string | `50m` | CPU request |
+| `resources.requests.memory` | string | `128Mi` | Memory request |
+| `resources.limits.cpu` | string | `500m` | CPU limit |
+| `resources.limits.memory` | string | `256Mi` | Memory limit |
+| `extraEnv` | list | `[]` | Additional environment variables |
+| `extraEnvFrom` | list | `[]` | Additional envFrom sources |
+| `podDisruptionBudget.enabled` | bool | `false` | Enable PDB |
+| `podDisruptionBudget.maxUnavailable` | int | `1` | Max unavailable pods during disruption |
+| `serviceAccount.create` | bool | `true` | Create a ServiceAccount |
+| `serviceAccount.name` | string | `""` | Override ServiceAccount name |
+| `probes.liveness.enabled` | bool | `true` | Enable liveness probe |
+| `probes.liveness.path` | string | `/healthz` | Liveness probe path |
+| `probes.readiness.enabled` | bool | `true` | Enable readiness probe |
+| `probes.readiness.path` | string | `/healthz` | Readiness probe path |
+
+## Fail-loud guards
+
+The chart includes render-time validation:
+
+- **Empty PAT token** — fails if `AUTH_MODE=pat` with no token and no `existingSecret`.
+- **PDB deadlock** — fails if `minAvailable >= replicaCount` (would block node drains).
+
+## Uninstalling
+
+```bash
+helm uninstall gitlab-mcp
+```

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,8 @@
+1. Get the application URL by running these commands:
+{{- if eq .Values.service.type "ClusterIP" }}
+  kubectl port-forward svc/{{ include "gitlab-mcp.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+  echo "MCP endpoint: http://localhost:{{ .Values.service.port }}/sse"
+{{- end }}
+
+2. In-cluster URL for MCP clients:
+   http://{{ include "gitlab-mcp.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/sse

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gitlab-mcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "gitlab-mcp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gitlab-mcp.labels" -}}
+helm.sh/chart: {{ include "gitlab-mcp.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "gitlab-mcp.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gitlab-mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gitlab-mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name
+*/}}
+{{- define "gitlab-mcp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gitlab-mcp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gitlab-mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "gitlab-mcp.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gitlab-mcp.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.PORT | default 3000 }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "gitlab-mcp.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret | default (include "gitlab-mcp.fullname" .) }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/chart/templates/pdb.yaml
+++ b/chart/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.podDisruptionBudget .Values.podDisruptionBudget.enabled }}
+{{- if and .Values.podDisruptionBudget.minAvailable (le (int .Values.replicaCount) (int .Values.podDisruptionBudget.minAvailable)) }}
+  {{- fail (printf "podDisruptionBudget.minAvailable (%d) >= replicaCount (%d) would deadlock node drains. Use maxUnavailable instead." (int .Values.podDisruptionBudget.minAvailable) (int .Values.replicaCount)) }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "gitlab-mcp.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.existingSecret }}
+{{- if and (eq .Values.config.AUTH_MODE "pat") (not .Values.secret.GITLAB_PERSONAL_ACCESS_TOKEN) }}
+  {{- fail "secret.GITLAB_PERSONAL_ACCESS_TOKEN is required when AUTH_MODE=pat and no existingSecret is set." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secret }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gitlab-mcp.selectorLabels" . | nindent 4 }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gitlab-mcp.serviceAccountName" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of pod replicas. Multi-replica requires sticky sessions."
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag. Overridden by CI at package time."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "config": {
+      "type": "object",
+      "description": "Non-sensitive environment variables injected via ConfigMap.",
+      "properties": {
+        "PORT": { "type": "string", "pattern": "^[0-9]+$" },
+        "USE_SSE": { "type": "string", "enum": ["true", "false"] },
+        "USE_STREAMABLE_HTTP": { "type": "string", "enum": ["true", "false"] },
+        "GITLAB_API_URL": { "type": "string", "format": "uri" },
+        "GITLAB_READ_ONLY_MODE": { "type": "string", "enum": ["true", "false"] },
+        "AUTH_MODE": {
+          "type": "string",
+          "enum": ["pat", "oauth"],
+          "description": "Authentication mode: 'pat' uses a static token, 'oauth' uses per-connection Bearer tokens."
+        },
+        "CORS_ALLOW_ORIGINS": {
+          "type": "string",
+          "description": "Comma-separated allowed CORS origins. Empty = '*' in PAT mode."
+        },
+        "HEALTHZ_MAX_SESSIONS": {
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "description": "Max sessions before /healthz returns 503."
+        }
+      }
+    },
+    "secret": {
+      "type": "object",
+      "description": "Sensitive values injected via Secret. Required when AUTH_MODE=pat and no existingSecret.",
+      "properties": {
+        "GITLAB_PERSONAL_ACCESS_TOKEN": { "type": "string" }
+      }
+    },
+    "existingSecret": {
+      "type": "string",
+      "description": "Name of an existing Secret to use instead of creating one."
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Pod resource requests and limits.",
+      "properties": {
+        "requests": { "type": "object" },
+        "limits": { "type": "object" }
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "description": "Extra env vars (list of {name, value} or {name, valueFrom}).",
+      "items": { "type": "object" }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "description": "Extra envFrom (list of secretRef/configMapRef).",
+      "items": { "type": "object" }
+    },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": "integer", "minimum": 1 },
+        "maxUnavailable": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "liveness": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" }
+          }
+        },
+        "readiness": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,87 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/yoda-digital/mcp-gitlab-server
+  # -- Image tag. Overridden by CI at package time.
+  # Default "latest" is safe for local helm install; tagged releases use semver.
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+# -- GitLab MCP server configuration (non-sensitive)
+config:
+  PORT: "3000"
+  USE_SSE: "true"
+  USE_STREAMABLE_HTTP: "false"
+  GITLAB_API_URL: "https://gitlab.com/api/v4"
+  GITLAB_READ_ONLY_MODE: "false"
+  # -- Authentication mode: "pat" (default) or "oauth"
+  # "pat"   : static token from GITLAB_PERSONAL_ACCESS_TOKEN env var / existingSecret
+  # "oauth" : per-connection Bearer token forwarded in the Authorization header
+  AUTH_MODE: "pat"
+  # -- Comma-separated list of allowed CORS origins.
+  # In PAT mode: defaults to "*" if empty. In OAuth mode: no default (deny).
+  CORS_ALLOW_ORIGINS: ""
+  # -- Max sessions before /healthz returns 503 (default 10000)
+  HEALTHZ_MAX_SESSIONS: "10000"
+
+# -- Sensitive values injected as env vars from a Secret.
+# Set these or use existingSecret.
+secret:
+  GITLAB_PERSONAL_ACCESS_TOKEN: ""
+
+# -- Use an existing Secret instead of creating one.
+# The Secret must contain the keys listed in secret{} above.
+existingSecret: ""
+
+service:
+  type: ClusterIP
+  port: 3000
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# -- Extra env vars (list of {name, value} or {name, valueFrom})
+extraEnv: []
+
+# -- Extra envFrom (list of secretRef/configMapRef)
+extraEnvFrom: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- PodDisruptionBudget (recommended when replicaCount > 1).
+# NOTE: SSE/Streamable HTTP transports hold in-memory session state.
+# Multi-replica requires sticky sessions — see docs/OPERATIONS.md.
+podDisruptionBudget:
+  enabled: false
+  # maxUnavailable: 1 is the safe default — works at any replicaCount.
+  maxUnavailable: 1
+
+podAnnotations: {}
+podLabels: {}
+
+serviceAccount:
+  create: true
+  name: ""
+
+# -- Liveness / readiness probes
+probes:
+  liveness:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 30
+  readiness:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 3
+    periodSeconds: 10


### PR DESCRIPTION
## Summary

Add production-ready container packaging, Kubernetes deployment via Helm, and automated CI/CD for building and publishing both artifacts.

### Dockerfile
- Multi-stage build: `node:24-alpine` builder + minimal runtime
- Non-root execution using built-in `node` user (uid 1000)
- Production-only dependencies (`npm ci --omit=dev`)
- Read-only root filesystem compatible (uses `/tmp` emptyDir volume)
- `.dockerignore` excludes `node_modules`, `dist`, `.git`, `chart/`

### Helm Chart (`chart/`)
- **Deployment** with security hardening:
  - `runAsNonRoot: true`, `runAsUser: 1000`
  - `seccompProfile: RuntimeDefault`
  - `readOnlyRootFilesystem: true`, `drop ALL` capabilities
- **ConfigMap** for non-sensitive config (`PORT`, `USE_SSE`, `GITLAB_API_URL`, `GITLAB_READ_ONLY_MODE`)
- **Secret** for `GITLAB_PERSONAL_ACCESS_TOKEN` (or `existingSecret` reference for external secret managers)
- **Service**, **ServiceAccount**, **PodDisruptionBudget**
- **Liveness/readiness probes** on `/healthz`
- `extraEnv` and `extraEnvFrom` for flexible secret injection

### GitHub Actions Workflow (`.github/workflows/build.yml`)
- Builds and pushes Docker image to `ghcr.io` on push/tag
- Packages and pushes Helm chart to `ghcr.io` OCI registry
- Automatic versioning from git tags (`vX.Y.Z` → `X.Y.Z`)
- Build cache via GitHub Actions cache (GHA)

### Health Endpoint
- Added `/healthz` endpoint to SSE transport returning `{"status":"ok"}`
- Required for Kubernetes liveness/readiness probes

## Environment Variables (via Helm values)

| Variable | Default | Description |
| --- | --- | --- |
| `PORT` | `3000` | HTTP listen port |
| `USE_SSE` | `true` | Enable SSE transport |
| `GITLAB_API_URL` | `https://gitlab.com/api/v4` | GitLab API base URL |
| `GITLAB_READ_ONLY_MODE` | `false` | Restrict to read-only tools |
| `GITLAB_PERSONAL_ACCESS_TOKEN` | (secret) | GitLab PAT |

## Quick Start

```bash
# Docker
docker build -t gitlab-mcp .
docker run -e GITLAB_PERSONAL_ACCESS_TOKEN=glpat-xxx -e USE_SSE=true -p 3000:3000 gitlab-mcp

# Helm
helm install gitlab-mcp ./chart \
  --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=glpat-xxx
```

## Testing
- All 41 existing tests pass
- Build succeeds with zero errors
- Dockerfile tested with Docker build
- Helm chart tested with `helm template`

## Checklist
- [x] Code follows Conventional Commits format
- [x] No version bump included
- [x] Tests pass (`npm test`)
- [x] Build passes (`npm run build`)
- [x] No breaking changes to existing functionality
