### PR TITLE
ci: migrate npm publish to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,14 @@ jobs:
       !contains(github.event.head_commit.message, 'update changelog [skip ci]')
     needs: build-and-test
     runs-on: ubuntu-latest
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/@yoda.digital/gitlab-mcp-server
     permissions:
       contents: read
+      # id-token: write is required for both:
+      #   1. npm OIDC trusted publishing (no NPM_TOKEN needed)
+      #   2. Sigstore-signed provenance attestations
       id-token: write
     steps:
       - uses: actions/checkout@v6
@@ -52,6 +58,13 @@ jobs:
           scope: "@yoda.digital"
       - run: npm ci
       - run: npm run build
+      # No NODE_AUTH_TOKEN. Authentication is via npm Trusted Publishing —
+      # configure on npmjs.com:
+      #   Package settings → Publishing access → Trusted publisher
+      #   Publisher: GitHub Actions
+      #   Organization: yoda-digital
+      #   Repository: mcp-gitlab-server
+      #   Workflow filename: .github/workflows/publish.yml
+      #   Environment name: npm-publish
+      # Reference: https://docs.npmjs.com/trusted-publishers
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Replace the long-lived `NPM_TOKEN` secret with [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) using GitHub's OIDC token. This is the modern, recommended way to publish to npm from GitHub Actions — no shared secrets, no token rotation, automatic Sigstore provenance.

## Why now

The `NPM_TOKEN` secret created on `2026-02-12` has been silently failing publishes since `2026-05-02`. The error npm returns for scoped packages when auth fails is a misleading `404 PUT /registry/@yoda.digital%2fgitlab-mcp-server - Not found` — it took some digging to identify the auth root cause. Rather than rotate the token (which would just defer the problem), this PR removes the token entirely.

## What changes

- `publish-npm` job no longer reads `NODE_AUTH_TOKEN`
- `publish-npm` job binds to a new GitHub deployment environment `npm-publish`, restricted to `main` branch and `v*` tag refs (defense in depth — the OIDC token's `environment` claim is bound to this scope, so a compromised contributor commit cannot publish from a feature branch)
- The existing `id-token: write` permission (already required for provenance signing) is sufficient — no new permissions
- `--provenance --access public` is kept; under trusted publishing, provenance is enforced automatically

## ⚠️ Required one-time manual setup on npmjs.com

Before merging this PR — or after merging if you are OK with one more publish failure in between — please configure the trusted publisher on the npm side:

1. Sign in to https://www.npmjs.com as the `@yoda.digital` organization owner
2. Navigate to: `@yoda.digital/gitlab-mcp-server` → **Settings** → **Publishing access**
3. Under **Trusted publishers**, click **Add trusted publisher**
4. Fill in:
   - Publisher: **GitHub Actions**
   - Organization: `yoda-digital`
   - Repository: `mcp-gitlab-server`
   - Workflow filename: `.github/workflows/publish.yml`
   - Environment name: `npm-publish`
5. Save

Reference: https://docs.npmjs.com/trusted-publishers#configuring-a-trusted-publisher-on-npmjscom

## Post-merge cleanup

After the first successful trusted-publish run is observed:

- Delete the `NPM_TOKEN` repository secret (Settings → Secrets and variables → Actions)
- Optionally rotate / revoke the npm legacy token at https://www.npmjs.com/settings/yoda-digital/tokens

## Verification

- The `build-and-test` job is unchanged and continues to pass on this PR
- The `publish-npm` job is gated to non-PR events, so this PR's own CI does not attempt to publish (verified during the 0.3.2 release)
- The `npm-publish` environment with branch policies for `main` + `v*` tags has already been provisioned via the GitHub API
- Once trusted publisher is configured on the npm side, the **next push to main with a version bump** will publish successfully without `NPM_TOKEN`

## Type of change

- [x] ci — workflow change

## Pre-merge checklist

- [x] No version bump needed (no runtime/API changes)
- [x] No CHANGELOG entry needed (CI-only change; will be mentioned in next release notes)
- [x] `npm test` passes
- [x] `npm run build` passes
- [x] Conventional Commits format on commit subject
- [x] No secrets in the diff