### PR TITLE
ci: install npm@latest before publish (Trusted Publishing needs npm >= 11.5.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,9 @@ jobs:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org/"
           scope: "@yoda.digital"
+      # npm Trusted Publishing requires npm >= 11.5.1 (introduced July 2025).
+      # Node 22 LTS Iron ships with npm 10.9.x, so we upgrade explicitly.
+      - run: npm install --global npm@latest
       - run: npm ci
       - run: npm run build
       # No NODE_AUTH_TOKEN. Authentication is via npm Trusted Publishing —


### PR DESCRIPTION
## Summary

Fixes the residual publish failure observed after merging #39 (OIDC Trusted Publishing migration). The npm CLI bundled with Node 22 LTS Iron is `10.9.x`, but **npm Trusted Publishing requires npm `>= 11.5.1`** (the version that introduced OIDC-based publish auth).

Without this step, the `publish-npm` job ran the new workflow with the right OIDC permissions, but the older npm CLI did not know how to exchange the GitHub-issued ID token for an npm publish credential. It fell back to the (now empty) `NODE_AUTH_TOKEN` path and failed with the same misleading `404 PUT /registry/@yoda.digital%2fgitlab-mcp-server - Not found` we saw before — even with the npm-side trusted publisher correctly configured by the owner.

## Change

One added step in the `publish-npm` job, immediately after `actions/setup-node@v6`:

```yaml
- run: npm install --global npm@latest
```

This upgrades the runner's npm to the current `11.x` line before `npm ci` and `npm publish` execute. No other workflow changes.

## Why not just bump Node to 24?

Node 24 ships npm 11+ natively and would solve this without an extra step. We could go that route in a follow-up, but Node 22 LTS is the conservative production runtime for npm packages — and the explicit `npm install --global npm@latest` step also documents the requirement in-place so the next maintainer doesn't trip on the same issue if Node version is ever rolled back.

## Verification plan

After merge, the next push to main (or any of the in-flight Dependabot PRs) will trigger the publish workflow with the upgraded npm. The expected log line that confirms Trusted Publishing is in use is:

```
npm notice publish Authenticating with npm via OIDC token from GitHub Actions
```

If we still see the `404 PUT` pattern, the issue is npm-side trusted publisher config (workflow filename or environment name mismatch) rather than CLI version.

## Type of change

- [x] ci — workflow change

## Pre-merge checklist

- [x] No version bump needed
- [x] No CHANGELOG entry needed (CI-only fix)
- [x] `npm test` unchanged and still passes
- [x] `npm run build` unchanged and still passes
- [x] Conventional Commits format on commit subject