### PR TITLE
ci: pin publish-npm to Node 24 (ships npm 11.12+ for Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,14 +51,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+      # Node 24 LTS Krypton ships with npm 11.12.x natively, which has the
+      # OIDC trusted-publishing client (introduced in npm 11.5.1, July 2025).
+      # build-and-test stays on Node 22 to mirror the production runtime.
       - uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org/"
           scope: "@yoda.digital"
-      # npm Trusted Publishing requires npm >= 11.5.1 (introduced July 2025).
-      # Node 22 LTS Iron ships with npm 10.9.x, so we upgrade explicitly.
-      - run: npm install --global npm@latest
       - run: npm ci
       - run: npm run build
       # No NODE_AUTH_TOKEN. Authentication is via npm Trusted Publishing —


### PR DESCRIPTION
## Summary

Replaces the brittle `npm install --global npm@latest` step from #40 with the proper fix: pin the `publish-npm` job to **Node 24 LTS Krypton**, which ships with `npm 11.12.x` natively and supports OIDC trusted-publishing without any post-install upgrade.

## Why the previous approach broke

`npm install --global npm@latest` on a Node 22 runner failed at module resolution time:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
...
```

`actions/setup-node@v6` installs Node 22 with bundled npm `10.9.x`. `npm install -g npm@latest` overlays `npm 11.x` on top, but the install does not fully clean `@npmcli/arborist`'s transitive deps from the 10.x tree — leaving the new npm with a missing `promise-retry` dependency.

This is a known footgun when straddling npm 10 → 11 in-place. The fix is to install the right Node version up-front instead of overlaying.

## Change

```diff
       - uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org/"
           scope: "@yoda.digital"
-      - run: npm install --global npm@latest
       - run: npm ci
```

`build-and-test` stays on Node 22 to mirror the production runtime — only the `publish-npm` job needs the newer npm CLI for trusted-publishing.

## Verification plan

After merge, the next push to `main` triggers `publish-npm` on Node 24 with npm 11.12.1+. Expected log line confirming Trusted Publishing:

```
npm notice publish Authenticating with npm via OIDC token from GitHub Actions
```

If we still see `404 PUT`, the issue is npm-side trusted publisher config (workflow filename or environment name mismatch) rather than CLI version.

## Type of change

- [x] ci — workflow change

## Pre-merge checklist

- [x] No version bump needed
- [x] No CHANGELOG entry needed
- [x] `npm test` unchanged (build-and-test still on Node 22)
- [x] `npm run build` unchanged
- [x] Conventional Commits format