### PR TITLE
feat(transport): add OAuth session auth and Streamable HTTP transport (rebase of #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Added
+
+- **OAuth per-connection authentication** (`AUTH_MODE=oauth`): new
+  `createMcpServer(token)` factory creates isolated Server + GitLabApi
+  instances per connection using the Bearer token from the `Authorization`
+  header. PAT mode (default) is unchanged.
+- **Streamable HTTP transport** (`USE_STREAMABLE_HTTP=true`): implements
+  the MCP Streamable HTTP spec on `POST/GET/DELETE /mcp` with session
+  management via `MCP-Session-Id` header.
+- **CORS origin allowlist** (`CORS_ALLOW_ORIGINS`): restrict allowed
+  origins in OAuth mode; permissive `*` default retained for PAT mode only.
+- `/healthz` endpoint with active session count and configurable
+  threshold (`HEALTHZ_MAX_SESSIONS`) for meaningful Kubernetes probes.
+- `docs/OPERATIONS.md` — operations guide covering health checks,
+  Kubernetes probe configuration, environment variables, and troubleshooting.
 
 ## [0.3.2] - 2026-05-04
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,57 @@
+# Operations Guide
+
+## Health Checks
+
+The `/healthz` endpoint returns:
+
+- `200 OK` with `{"status":"ok","sessions":<n>}` when healthy.
+- `503 Service Unavailable` with `{"status":"unhealthy","reason":"session_limit_exceeded","sessions":<n>}` when active sessions exceed `HEALTHZ_MAX_SESSIONS` (default: 10000).
+
+### Kubernetes Probe Configuration
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 3000
+  initialDelaySeconds: 5
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 3000
+  initialDelaySeconds: 3
+  periodSeconds: 10
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `3000` | HTTP listen port |
+| `USE_SSE` | `false` | Enable legacy SSE transport |
+| `USE_STREAMABLE_HTTP` | `false` | Enable MCP Streamable HTTP transport |
+| `AUTH_MODE` | `pat` | `pat` or `oauth` |
+| `GITLAB_API_URL` | `https://gitlab.com/api/v4` | GitLab API base URL |
+| `GITLAB_PERSONAL_ACCESS_TOKEN` | — | Required in `pat` mode |
+| `GITLAB_READ_ONLY_MODE` | `false` | Restrict to read-only tools |
+| `CORS_ALLOW_ORIGINS` | — | Comma-separated allowed origins (empty = `*` in PAT mode, deny in OAuth mode) |
+| `HEALTHZ_MAX_SESSIONS` | `10000` | Session count threshold for unhealthy status |
+
+## Troubleshooting
+
+### Server returns 401 on every request
+
+- **OAuth mode**: Verify the upstream gateway is forwarding the `Authorization: Bearer <token>` header.
+- **PAT mode**: Ensure `GITLAB_PERSONAL_ACCESS_TOKEN` is set and the token has not expired.
+
+### High session count / memory growth
+
+Active sessions are stored in-memory. If session count grows unbounded:
+
+1. Check that clients are properly closing SSE connections or sending `DELETE /mcp`.
+2. Consider lowering `HEALTHZ_MAX_SESSIONS` and adding a horizontal pod autoscaler based on the `/healthz` response.
+
+### CORS errors in browser console
+
+In OAuth mode, `Access-Control-Allow-Origin: *` is intentionally **not** sent. Set `CORS_ALLOW_ORIGINS` to the exact origin(s) of your frontend application.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -2463,13 +2463,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,31 +143,19 @@ const GITLAB_PERSONAL_ACCESS_TOKEN = process.env.GITLAB_PERSONAL_ACCESS_TOKEN;
 const GITLAB_API_URL = process.env.GITLAB_API_URL || 'https://gitlab.com/api/v4';
 const PORT = parseInt(process.env.PORT || '3000', 10);
 const USE_SSE = process.env.USE_SSE === 'true';
+const USE_STREAMABLE_HTTP = process.env.USE_STREAMABLE_HTTP === 'true';
 const GITLAB_READ_ONLY_MODE = process.env.GITLAB_READ_ONLY_MODE === 'true';
-
-if (!GITLAB_PERSONAL_ACCESS_TOKEN) {
-  console.error("GITLAB_PERSONAL_ACCESS_TOKEN environment variable is not set");
+/**
+ * Authentication mode:
+ *   - "pat"   (default) : static Personal Access Token from GITLAB_PERSONAL_ACCESS_TOKEN env var
+ *   - "oauth" : per-connection Bearer token forwarded in each SSE request Authorization header
+ */
+const AUTH_MODE_RAW = (process.env.AUTH_MODE || 'pat').toLowerCase();
+if (AUTH_MODE_RAW !== 'pat' && AUTH_MODE_RAW !== 'oauth') {
+  console.error(`Invalid AUTH_MODE="${process.env.AUTH_MODE}". Must be "pat" or "oauth".`);
   process.exit(1);
 }
-
-// Server capabilities
-const serverCapabilities: ServerCapabilities = {
-  tools: {}
-};
-
-// Create server
-const server = new Server({
-  name: "gitlab-mcp-server",
-  version: packageJson.version,
-}, {
-  capabilities: serverCapabilities
-});
-
-// Create GitLab API client
-const gitlabApi = new GitLabApi({
-  apiUrl: GITLAB_API_URL,
-  token: GITLAB_PERSONAL_ACCESS_TOKEN
-});
+const AUTH_MODE: 'pat' | 'oauth' = AUTH_MODE_RAW as 'pat' | 'oauth';
 
 // Helper function to convert Zod schema to JSON schema with proper type
 function createJsonSchema(schema: z.ZodType<any>) {
@@ -721,6 +709,26 @@ const ALL_TOOLS = [
     readOnly: false
   },
 ];
+
+/**
+ * Create and configure a new MCP server instance for a given GitLab token.
+ * Called once at startup in PAT mode, or once per SSE connection in OAuth mode.
+ */
+export function createMcpServer(token: string): Server {
+  // Create server
+  const serverCapabilities: ServerCapabilities = { tools: {} };
+  const server = new Server({
+    name: "gitlab-mcp-server",
+    version: packageJson.version,
+  }, {
+    capabilities: serverCapabilities
+  });
+
+  // Create GitLab API client
+  const gitlabApi = new GitLabApi({
+    apiUrl: GITLAB_API_URL,
+    token,
+  });
 
 // Register tool handlers
 server.setRequestHandler(ListToolsRequestSchema, async (): Promise<ListToolsResult> => {
@@ -1835,11 +1843,42 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
   }
 });
 
+  return server;
+} // end createMcpServer
+
 // Start the server
 async function runServer() {
   try {
-    await setupTransport(server, { port: PORT, useSSE: USE_SSE });
-    console.error(`GitLab MCP Server running with ${USE_SSE ? 'SSE' : 'stdio'} transport`);
+    if (AUTH_MODE === 'oauth') {
+      if (!USE_SSE && !USE_STREAMABLE_HTTP) {
+        console.error("AUTH_MODE=oauth requires USE_SSE=true or USE_STREAMABLE_HTTP=true");
+        process.exit(1);
+      }
+      await setupTransport(null, {
+        port: PORT,
+        useSSE: USE_SSE,
+        useStreamableHttp: USE_STREAMABLE_HTTP,
+        serverFactory: createMcpServer
+      });
+    } else {
+      // PAT mode (default)
+      if (!GITLAB_PERSONAL_ACCESS_TOKEN) {
+        console.error("GITLAB_PERSONAL_ACCESS_TOKEN environment variable is not set");
+        process.exit(1);
+      }
+      const server = createMcpServer(GITLAB_PERSONAL_ACCESS_TOKEN);
+      await setupTransport(server, {
+        port: PORT,
+        useSSE: USE_SSE,
+        useStreamableHttp: USE_STREAMABLE_HTTP,
+      });
+    }
+    const enabledTransports = [
+      USE_SSE ? 'sse' : null,
+      USE_STREAMABLE_HTTP ? 'streamable-http' : null,
+      !USE_SSE && !USE_STREAMABLE_HTTP ? 'stdio' : null,
+    ].filter(Boolean).join(', ');
+    console.error(`GitLab MCP Server running with ${enabledTransports} transport(s) (auth: ${AUTH_MODE})`);
   } catch (error) {
     console.error("Error starting server:", error);
     process.exit(1);

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { setupTransport } from './transport.js';
+import http from 'http';
+
+/**
+ * Integration tests for transport.ts:
+ * - Bearer token extraction (OAuth mode)
+ * - Streamable HTTP session lifecycle
+ * - Cross-protocol session collision
+ * - CORS origin handling
+ * - /healthz endpoint
+ */
+
+// Helper: make HTTP request and return response
+function request(
+  port: number,
+  method: string,
+  path: string,
+  headers: Record<string, string> = {},
+  body?: string
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, method, path, headers },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => resolve({ status: res.statusCode!, headers: res.headers, body: data }));
+      }
+    );
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+// Helper: make request that resolves as soon as status + headers arrive (for SSE)
+function requestStatus(
+  port: number,
+  method: string,
+  path: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; destroy: () => void }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, method, path, headers },
+      (res) => {
+        resolve({
+          status: res.statusCode!,
+          headers: res.headers,
+          destroy: () => { res.destroy(); req.destroy(); }
+        });
+      }
+    );
+    req.on('error', (err) => {
+      // Ignore ECONNRESET from destroy()
+      if ((err as NodeJS.ErrnoException).code !== 'ECONNRESET') reject(err);
+    });
+    req.end();
+  });
+}
+
+// Helper: create a minimal MCP server that responds to list_tools
+function createTestServer(token: string): Server {
+  const server = new Server(
+    { name: 'test-server', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [{ name: 'test_tool', description: `Tool for ${token}`, inputSchema: { type: 'object' as const, properties: {} } }]
+  }));
+  return server;
+}
+
+describe('Transport — OAuth Bearer extraction', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19100 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    await setupTransport(null, {
+      port,
+      useSSE: true,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await request(port, 'GET', '/sse');
+    expect(res.status).toBe(401);
+    expect(res.body).toContain('Unauthorized');
+  });
+
+  it('returns 401 when Authorization header has no Bearer prefix', async () => {
+    const res = await request(port, 'GET', '/sse', { Authorization: 'Basic abc123' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when Bearer token is empty', async () => {
+    const res = await request(port, 'GET', '/sse', { Authorization: 'Bearer ' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for malformed Authorization (no space after Bearer)', async () => {
+    const res = await request(port, 'GET', '/sse', { Authorization: 'Bearertoken123' });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts case-variant "bearer" (lowercase)', async () => {
+    const { status, destroy } = await requestStatus(port, 'GET', '/sse', { Authorization: 'bearer my-token-123' });
+    expect(status).toBe(200);
+    destroy();
+  });
+
+  it('accepts case-variant "BEARER" (uppercase)', async () => {
+    const { status, destroy } = await requestStatus(port, 'GET', '/sse', { Authorization: 'BEARER MY-TOKEN-456' });
+    expect(status).toBe(200);
+    destroy();
+  });
+
+  it('returns 401 for Streamable HTTP POST /mcp without Authorization', async () => {
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const res = await request(port, 'POST', '/mcp', {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream'
+    }, initPayload);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('Transport — Streamable HTTP session lifecycle', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19200 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    await setupTransport(null, {
+      port,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('initializes a session and returns MCP-Session-Id', async () => {
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const res = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        Authorization: 'Bearer test-token'
+      },
+      initPayload
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers['mcp-session-id']).toBeDefined();
+    expect(res.headers['mcp-session-id']).toMatch(/^[0-9a-f-]+$/);
+  });
+
+  it('reuses an existing session with valid MCP-Session-Id', async () => {
+    // First: initialize
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const initRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        Authorization: 'Bearer reuse-token'
+      },
+      initPayload
+    );
+    const sessionId = initRes.headers['mcp-session-id'] as string;
+    expect(sessionId).toBeDefined();
+
+    // Send initialized notification
+    const initializedPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized'
+    });
+    await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': sessionId
+      },
+      initializedPayload
+    );
+
+    // Second: list_tools on same session
+    const listPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {}
+    });
+    const listRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': sessionId
+      },
+      listPayload
+    );
+    expect(listRes.status).toBe(200);
+    // Response may be plain JSON or SSE-wrapped depending on SDK version
+    let body: any;
+    if (listRes.body.startsWith('event:') || listRes.body.startsWith('data:')) {
+      // Parse SSE format: extract JSON from "data: {...}" lines
+      const dataLine = listRes.body.split('\n').find(l => l.startsWith('data: '));
+      body = JSON.parse(dataLine!.replace('data: ', ''));
+    } else {
+      body = JSON.parse(listRes.body);
+    }
+    expect(body.result.tools).toBeDefined();
+    expect(body.result.tools[0].name).toBe('test_tool');
+  });
+
+  it('cleans up session on DELETE /mcp', async () => {
+    // Initialize
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const initRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        Authorization: 'Bearer cleanup-token'
+      },
+      initPayload
+    );
+    const sessionId = initRes.headers['mcp-session-id'] as string;
+    expect(sessionId).toBeDefined();
+
+    // DELETE to close the session
+    const delRes = await request(
+      port, 'DELETE', '/mcp',
+      { 'MCP-Session-Id': sessionId }
+    );
+    // 200 or 204 — session terminated
+    expect([200, 204]).toContain(delRes.status);
+
+    // Attempt to reuse closed session → should fail
+    const reusePayload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {}
+    });
+    const reuseRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': sessionId
+      },
+      reusePayload
+    );
+    // Session no longer exists — should get 400 (session not found)
+    expect(reuseRes.status).toBe(400);
+    const reuseBody = JSON.parse(reuseRes.body);
+    expect(reuseBody.error.message).toContain('Session not found');
+  });
+});
+
+describe('Transport — cross-protocol session collision', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19300 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    await setupTransport(null, {
+      port,
+      useSSE: true,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('returns 400 when using a non-existent session ID on Streamable HTTP endpoint', async () => {
+    const payload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {}
+    });
+    const mcpRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      },
+      payload
+    );
+    expect(mcpRes.status).toBe(400);
+    const body = JSON.parse(mcpRes.body);
+    expect(body.error.message).toContain('Bad Request');
+  });
+
+  it('returns 400 when SSE session ID is used on Streamable HTTP endpoint', async () => {
+    // First create an SSE connection to get a real session in the transports map
+    const { status, destroy } = await requestStatus(port, 'GET', '/sse', {
+      Authorization: 'Bearer collision-token'
+    });
+    expect(status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The SSE session ID is internal; we simulate by using a random UUID
+    // that could theoretically collide. The transport type check is what matters.
+    const payload = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {}
+    });
+    const mcpRes = await request(
+      port, 'POST', '/mcp',
+      {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'MCP-Session-Id': 'fake-collision-id'
+      },
+      payload
+    );
+    // Not found as StreamableHTTP → 400
+    expect(mcpRes.status).toBe(400);
+    destroy();
+  });
+});
+
+describe('Transport — /healthz endpoint', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19400 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'pat';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    const server = createTestServer('pat-token');
+    await setupTransport(server, { port, useSSE: true });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('returns 200 with status ok and session count', async () => {
+    const res = await request(port, 'GET', '/healthz');
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('ok');
+    expect(typeof body.sessions).toBe('number');
+  });
+
+  it('returns incremented session count after SSE connection', async () => {
+    // Get baseline
+    const beforeRes = await request(port, 'GET', '/healthz');
+    const before = JSON.parse(beforeRes.body).sessions;
+
+    // Open an SSE connection (PAT mode — reuses single server)
+    const { status, destroy } = await requestStatus(port, 'GET', '/sse');
+    expect(status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const afterRes = await request(port, 'GET', '/healthz');
+    const after = JSON.parse(afterRes.body).sessions;
+    expect(after).toBeGreaterThan(before);
+
+    destroy();
+  });
+});
+
+describe('Transport — CORS origin handling', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19500 + Math.floor(Math.random() * 900);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = 'https://app.example.com,https://admin.example.com';
+    await setupTransport(null, {
+      port,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('sets Allow-Origin for allowlisted origin', async () => {
+    const res = await request(port, 'OPTIONS', '/mcp', { Origin: 'https://app.example.com' });
+    expect(res.status).toBe(204);
+    expect(res.headers['access-control-allow-origin']).toBe('https://app.example.com');
+  });
+
+  it('does NOT set Allow-Origin for non-allowlisted origin', async () => {
+    const res = await request(port, 'OPTIONS', '/mcp', { Origin: 'https://evil.com' });
+    expect(res.status).toBe(204);
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('does NOT set Allow-Origin when no Origin header is sent', async () => {
+    const res = await request(port, 'GET', '/healthz');
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,8 +1,27 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { randomUUID } from "crypto";
 import { createServer, IncomingMessage, ServerResponse } from "http";
 import { parse } from "url";
+
+/**
+ * CORS origin allowlist parsed from CORS_ALLOW_ORIGINS env var.
+ * - When empty AND AUTH_MODE=pat: permissive `*` (single-tenant local dev).
+ * - When empty AND AUTH_MODE=oauth: no Allow-Origin header (deny browser access).
+ * - When set: only listed origins receive the Allow-Origin header.
+ *
+ * Read lazily at request time to support runtime configuration and testing.
+ */
+function getCorsAllowedOrigins(): string[] {
+  return (process.env.CORS_ALLOW_ORIGINS ?? '')
+    .split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function getAuthModeEnv(): string {
+  return (process.env.AUTH_MODE || 'pat').toLowerCase();
+}
 
 /**
  * Transport configuration options
@@ -12,36 +31,83 @@ export interface TransportOptions {
    * Port to use for SSE transport (default: 3000)
    */
   port?: number;
-  
+
   /**
    * Whether to use SSE transport (default: false, uses stdio)
    */
   useSSE?: boolean;
+
+  /**
+   * Whether to enable Streamable HTTP transport on /mcp (default: false).
+   * Can be enabled together with legacy SSE transport.
+   */
+  useStreamableHttp?: boolean;
+
+  /**
+   * Optional factory function used in OAuth mode.
+   * When provided, a new MCP Server is created per SSE connection
+   * using the Bearer token extracted from the Authorization header.
+   * If absent, the `server` argument is used directly (PAT mode).
+   */
+  serverFactory?: (token: string) => Server;
 }
 
 /**
  * Sets up the appropriate transport for the server based on the options
- * 
- * @param server - The MCP server instance
+ *
+ * @param server - The MCP server instance (PAT mode). Pass null when using serverFactory.
  * @param options - Transport configuration options
  * @returns A promise that resolves when the transport is set up
  */
 export async function setupTransport(
-  server: Server,
+  server: Server | null,
   options: TransportOptions = {}
 ): Promise<void> {
-  const { port = 3000, useSSE = false } = options;
+  const { port = 3000, useSSE = false, useStreamableHttp = false, serverFactory } = options;
 
-  if (useSSE) {
-    // Create an object to store active SSE transports by session ID
-    const transports: { [sessionId: string]: SSEServerTransport } = {};
+  const getSessionServer = (req: IncomingMessage): Server | null => {
+    if (!serverFactory) {
+      // PAT mode: reuse the single pre-built server.
+      return server;
+    }
+
+    // OAuth mode: extract Bearer token from Authorization header.
+    const authHeader = req.headers["authorization"] || "";
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (!match) {
+      return null;
+    }
+    return serverFactory(match[1].trim());
+  };
+
+  if (useSSE || useStreamableHttp) {
+    // Store active transports by session ID for both legacy SSE and Streamable HTTP.
+    const transports: {
+      [sessionId: string]: SSEServerTransport | StreamableHTTPServerTransport;
+    } = {};
 
     // Create raw HTTP server
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-      // Enable CORS
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      // CORS handling — restrict origins in OAuth mode
+      const corsOrigins = getCorsAllowedOrigins();
+      const authMode = getAuthModeEnv();
+      const requestOrigin = req.headers.origin;
+      let corsAllowed = false;
+      if (requestOrigin && corsOrigins.length > 0 && corsOrigins.includes(requestOrigin)) {
+        res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+        res.setHeader('Vary', 'Origin');
+        corsAllowed = true;
+      } else if (corsOrigins.length === 0 && authMode === 'pat') {
+        // Single-tenant local dev — keep permissive default
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        corsAllowed = true;
+      }
+      // else: no Allow-Origin header → browser refuses to surface the response
+
+      if (corsAllowed) {
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, MCP-Session-Id');
+      }
 
       if (req.method === 'OPTIONS') {
         res.writeHead(204);
@@ -52,26 +118,148 @@ export async function setupTransport(
       const { pathname, query } = parse(req.url || '', true);
 
       try {
-        if (req.method === 'GET' && pathname === '/sse') {
-          // Create a new SSE transport
-          const transport = new SSEServerTransport("/messages", res);
-          
-          // Store the transport by session ID
-          transports[transport.sessionId] = transport;
-          
-          // Set up cleanup handler
-          req.on("close", () => {
-            delete transports[transport.sessionId];
-          });
+        if (req.method === 'GET' && pathname === '/healthz') {
+          const sessionCount = Object.keys(transports).length;
+          const maxSessions = parseInt(process.env.HEALTHZ_MAX_SESSIONS || '10000', 10);
+          if (sessionCount > maxSessions) {
+            res.writeHead(503, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'unhealthy', reason: 'session_limit_exceeded', sessions: sessionCount }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok', sessions: sessionCount }));
+        }
+        else if (useStreamableHttp && pathname === '/mcp' && (req.method === 'GET' || req.method === 'POST' || req.method === 'DELETE')) {
+          const sessionIdHeader = req.headers['mcp-session-id'];
+          const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
 
-          // Connect the server to the transport
-          await server.connect(transport);
+          let transport: StreamableHTTPServerTransport | null = null;
+          if (sessionId) {
+            const existingTransport = transports[sessionId];
+            if (existingTransport instanceof StreamableHTTPServerTransport) {
+              transport = existingTransport;
+            } else if (existingTransport) {
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32000,
+                  message: 'Bad Request: Session exists but uses a different transport protocol'
+                },
+                id: null
+              }));
+              return;
+            } else {
+              // Session ID was provided but not found — reject
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32000,
+                  message: 'Bad Request: Session not found or expired'
+                },
+                id: null
+              }));
+              return;
+            }
+          }
+
+          if (!transport && req.method === 'POST') {
+            const sessionServer = getSessionServer(req);
+            if (!sessionServer) {
+              res.writeHead(401, { 'Content-Type': 'text/plain' });
+              res.end('Unauthorized: missing or invalid Authorization: Bearer <token> header');
+              return;
+            }
+
+            let initializedSid: string | undefined;
+            const newTransport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: () => randomUUID(),
+              onsessioninitialized: (sid: string) => {
+                initializedSid = sid;
+                transports[sid] = newTransport;
+              }
+            });
+
+            newTransport.onclose = () => {
+              const sid = newTransport.sessionId;
+              if (sid && transports[sid] === newTransport) {
+                delete transports[sid];
+              }
+            };
+
+            try {
+              await sessionServer.connect(newTransport);
+            } catch (connectError) {
+              // Clean up if connect fails — onsessioninitialized may have fired
+              if (initializedSid) delete transports[initializedSid];
+              try { await newTransport.close?.(); } catch { /* best-effort */ }
+              throw connectError;
+            }
+            transport = newTransport;
+          }
+
+          if (!transport) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              jsonrpc: '2.0',
+              error: {
+                code: -32000,
+                message: 'Bad Request: No valid session ID provided'
+              },
+              id: null
+            }));
+            return;
+          }
+
+          await transport.handleRequest(req, res);
+        }
+        else if (req.method === 'GET' && pathname === '/sse') {
+          if (!useSSE) {
+            res.writeHead(404);
+            res.end();
+            return;
+          }
+
+          // Determine which server instance to use for this connection
+          const sessionServer = getSessionServer(req);
+          if (!sessionServer) {
+            res.writeHead(401, { 'Content-Type': 'text/plain' });
+            res.end('Unauthorized: missing or invalid Authorization: Bearer <token> header');
+            return;
+          }
+
+          // Create a new SSE transport
+          const sseTransport = new SSEServerTransport("/messages", res);
+
+          // Idempotent cleanup helper
+          const cleanupSse = () => {
+            if (transports[sseTransport.sessionId] === sseTransport) {
+              delete transports[sseTransport.sessionId];
+            }
+          };
+
+          // Clean up on TCP close
+          req.on("close", cleanupSse);
+
+          // Clean up on SDK-initiated graceful close
+          sseTransport.onclose = cleanupSse;
+
+          // Connect the server to the transport — only register on success
+          await sessionServer.connect(sseTransport);
+          transports[sseTransport.sessionId] = sseTransport;
         }
         else if (req.method === 'POST' && pathname === '/messages') {
+          if (!useSSE) {
+            res.writeHead(404);
+            res.end();
+            return;
+          }
+
           const sessionId = query.sessionId as string;
           const transport = transports[sessionId];
-          
-          if (!transport) {
+
+          if (!(transport instanceof SSEServerTransport)) {
             res.writeHead(400);
             res.end('No transport found for sessionId');
             return;
@@ -98,8 +286,8 @@ export async function setupTransport(
       console.error(`SSE server listening on port ${port}`);
     });
   } else {
-    // Set up stdio transport
+    // Set up stdio transport (PAT mode only — server is always provided)
     const transport = new StdioServerTransport();
-    await server.connect(transport);
+    await server!.connect(transport);
   }
 }


### PR DESCRIPTION
Rebase fixup of #28 onto current main. All implementation work authored by @ecthelion77; rebase + dependency restoration by maintainer.

## Why a new PR

#28's squash commit dropped a few mechanical bits when main moved during the contributor's response window:

- `package.json` reverted recent dep bumps (typescript 6 from #35, express 5 from #36, the `vite ^8` security override from #38)
- `CHANGELOG.md` was missing the `[0.3.2] - 2026-05-04` entry that landed today

Rather than ask the contributor to rebase again for shifts I caused, I rebased their branch myself, restored the dropped pieces, regenerated the lockfile, and verified locally:

- 58/58 vitest tests pass
- `npm audit`: 0 vulnerabilities
- `npm run build`: clean
- Diff vs `main` is clean intent only (+814 / -61 across 7 files)

## Attribution

`git log` for the rebased commit:

```
Author:    Olivier Gintrand <olivier.gintrand@forterro.com>
Committer: nalyk <dev.ungheni@gmail.com>
Subject:   feat(transport): add OAuth session auth and Streamable HTTP transport
```

The squash-merge commit message will carry a `Co-authored-by:` trailer so the contributor is credited on the GitHub contribution graph.

## What this PR adds (verbatim from #28's verified scope)

- **OAuth per-connection authentication** (`AUTH_MODE=oauth`): `createMcpServer(token)` factory creates isolated `Server` + `GitLabApi` per connection; PAT mode unchanged.
- **Streamable HTTP transport** (`USE_STREAMABLE_HTTP=true`): MCP Streamable HTTP spec on `POST/GET/DELETE /mcp` with `MCP-Session-Id` session management. Cross-protocol session ID collisions and unknown sessions return 400 JSON-RPC errors. Memory-leak-safe `connect()` via `initializedSid` capture + best-effort `close()` on failure.
- **CORS origin allowlist** (`CORS_ALLOW_ORIGINS`): OAuth mode default-denies browser origins; PAT mode keeps permissive `*` for local dev. `Vary: Origin` set when echoing.
- **AUTH_MODE fail-fast**: invalid env values exit with `process.exit(1)` and a clear message at startup.
- **`/healthz`**: returns `{"status":"ok","sessions":<n>}` or `503 {"status":"unhealthy","reason":"session_limit_exceeded","sessions":<n>}` when active sessions exceed `HEALTHZ_MAX_SESSIONS` (default 10000). Real signal for Kubernetes probes.
- **17 new vitest tests** in `src/transport.test.ts` covering Bearer extraction (7), Streamable HTTP lifecycle (3), cross-protocol collision (2), `/healthz` (2), CORS origin handling (3).
- **`docs/OPERATIONS.md`** — operations guide (health checks, K8s probes, env var reference, troubleshooting).
- **`package.json` version bump** to `0.4.0`.

## Cross-PR coordination

#29 still has a `/healthz` block in `src/transport.ts` that conflicts with this PR's. After this lands, #29 will need to drop its `/healthz` add during its own rebase. Keeping `blocked: cross-pr-conflict` label on this PR until #29 is reconciled.

## Closes

Closes #28.