### PR TITLE
ci(publish): decouple publish from push events (release-driven model)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,21 @@
 name: Publish Package to npm
 
+# Release-driven publish model:
+# - build-and-test runs on every code event (PR + push to main + release + manual
+#   dispatch). PR-time check satisfies the branch-protection ruleset; the push
+#   trigger is the safety net for admin-bypass merges and post-merge sanity on
+#   Dependabot auto-merges.
+# - publish-npm runs ONLY on a published GitHub Release or a manual
+#   workflow_dispatch. Code landing on main does NOT publish — releases are
+#   deliberate, versioned ceremonies.
+#
+# Why this shape: every commit that touches non-md used to trigger publish-npm,
+# which (a) failed loudly when no version bump (Dependabot patches, doc
+# changes, contributor iterations) and (b) raced with the release event when a
+# release was created for the same SHA. Decoupling code-events from
+# release-events fixes both classes of failure and aligns with the publish flow
+# of mature npm projects (React, Vite, vitest, etc.).
+
 on:
   push:
     branches:
@@ -12,14 +28,18 @@ on:
     paths-ignore:
       - "**.md"
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
   build-and-test:
-    # Skip if the commit message contains "update changelog [skip ci]"
+    # Skip GitHub Actions changelog auto-commits to avoid double-runs on bot
+    # pushes. The condition only meaningfully applies on push events; on PR /
+    # release / dispatch, github.event.head_commit is null, contains() returns
+    # false, and the negation runs the job.
     if: ${{ !contains(github.event.head_commit.message, 'update changelog [skip ci]') }}
     runs-on: ubuntu-latest
     steps:
@@ -33,11 +53,10 @@ jobs:
       - run: npm test
 
   publish-npm:
-    # Only publish on push to main or release events; skip on PRs and on
-    # changelog-only auto-commits.
-    if: >-
-      github.event_name != 'pull_request' &&
-      !contains(github.event.head_commit.message, 'update changelog [skip ci]')
+    # Only publish on a published GitHub Release (deliberate ceremony) or on
+    # manual workflow_dispatch (escape hatch for emergencies). Never on push
+    # or pull_request — those are code events, not release events.
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: build-and-test
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary

Refactor `publish.yml` to a **release-driven** model. Code landing on `main` no longer triggers `npm publish`; only published GitHub Releases (or manual `workflow_dispatch`) do.

## Why

Today's session surfaced four distinct failure modes of the current "publish on every push to main" trigger — all sharing one root cause (conflating *code-event* with *release-event*):

1. **Failed publish on every Dependabot patch merge** — package.json version unchanged → npm rejects → red ❌ on every dep PR.
2. **Failed publish on every doc/infra merge that wasn't `paths-ignore`'d** — same shape.
3. **The NPM_TOKEN expiry was masked for weeks** — every commit failing publish silently looked like normal noise; the misleading `404 PUT scoped-pkg` error (npm's auth-fail-as-404 quirk) compounded the masking.
4. **The push + release race on the v0.4.0 cut** — squash-merge to main fired a `push` event, `gh release create v0.4.0` fired a `release` event, both queued `publish-npm` for the same SHA. First won (clean publish + provenance), second failed with the same misleading 404.

The mature pattern (React, Next.js, Vite, vitest, etc.) is **release-driven**: code lands freely on main, releases are deliberate, versioned ceremonies. This PR aligns us with that.

## Change

```diff
 on:
   push:
     branches: [main]
     paths-ignore: ["**.md"]
   pull_request:
     branches: [main]
     paths-ignore: ["**.md"]
   release:
-    types: [created]
+    types: [published]   # 'published' fires on actual publication, not draft creation
+  workflow_dispatch: {}  # escape hatch for emergencies (e.g., transient npm/registry failure)
 
 jobs:
   build-and-test:
     # runs on every event — branch-protection gate stays satisfied on PR;
     # admin-bypass and Dependabot push-to-main get post-merge sanity check
     ...
 
   publish-npm:
-    if: >-
-      github.event_name != 'pull_request' &&
-      !contains(github.event.head_commit.message, 'update changelog [skip ci]')
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: build-and-test
     ...
```

## Behavioral matrix

| Event | `build-and-test` | `publish-npm` |
| --- | --- | --- |
| Open / update PR | ✅ runs (gates merge) | ⏭️ skipped |
| Squash-merge to `main` | ✅ runs (post-merge sanity) | ⏭️ skipped |
| Admin-bypass push to `main` | ✅ runs (safety net) | ⏭️ skipped |
| Md-only push (paths-ignored) | ⏭️ skipped | ⏭️ skipped |
| `gh release create vX.Y.Z` (published) | ✅ runs | ✅ **publishes** |
| Manual `workflow_dispatch` | ✅ runs | ✅ **publishes** |
| Draft-only release | ⏭️ skipped | ⏭️ skipped |

Zero race conditions. Zero failed publishes on regular merges. CI verification preserved on every code path.

## Compatibility checks (validated against current setup)

- Branch protection ruleset (id `15919136`) requires `build-and-test` + `Analyze (javascript-typescript)` — both still appear on PRs. ✓
- Dependabot auto-merge — works cleanly, no publish noise. ✓
- `npm-publish` deployment environment with branch policies (`main` + `v*` tags) — covers both `release` and `workflow_dispatch` paths. ✓
- npm Trusted Publishing config on npmjs.com — unchanged (workflow filename + environment name match). ✓
- Sigstore SLSA v1 provenance — unchanged (`--provenance --access public` flag preserved). ✓
- CHANGELOG `[skip ci]` auto-commit skip — preserved as forward-compat (no current bot, but pattern documented in CLAUDE.md). ✓
- `paths-ignore: ["**.md"]` — preserved for `push` + `pull_request`, intentionally absent on `release` (release events should always publish regardless of file types). ✓
- PR #29's separate `build.yml` (Docker + Helm to ghcr.io) — independent target registry, no race. ✓
- CodeQL workflow — independent, no interaction. ✓

## Type of change

- [x] ci — workflow change

## Pre-merge checklist

- [x] No version bump needed
- [x] No CHANGELOG entry needed (CI-only, no user-visible runtime change)
- [x] `npm test` unchanged (still runs on every code event)
- [x] `npm run build` unchanged
- [x] Conventional Commits format on commit subject
- [x] No secrets in the diff