### PR TITLE
feat: add Dockerfile, Helm chart, and CI/CD workflow (rebase of #29)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+npm-debug.log
+.git
+.github
+chart
+*.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,139 @@
+name: "Build & Publish"
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}  # yoda-digital/mcp-gitlab-server
+  CHART_NAME: gitlab-mcp
+
+permissions:
+  contents: read
+  packages: write
+
+# -------------------------------------------------------------------
+# Job 1 — Validate (runs on every push and PR)
+# -------------------------------------------------------------------
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Helm lint
+        run: |
+          helm lint chart/ \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=dummy-for-lint
+
+      - name: Helm template smoke test
+        run: |
+          helm template test-release chart/ \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=dummy-for-lint \
+            > /dev/null
+
+  # -------------------------------------------------------------------
+  # Job 2 — Docker build + push (skipped on PRs)
+  # -------------------------------------------------------------------
+  docker:
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name != 'pull_request'
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # On tag push: v1.2.3 -> 1.2.3 + latest
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            # On main push (no tag): sha-<short>
+            type=sha,prefix=,enable=${{ github.ref_type != 'tag' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # -------------------------------------------------------------------
+  # Job 3 — Helm package + push (only on tags)
+  # -------------------------------------------------------------------
+  helm:
+    runs-on: ubuntu-latest
+    needs: docker
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Log in to ghcr.io (Helm OCI)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Compute version
+        id: version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update appVersion in Chart.yaml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          yq -i ".appVersion = \"$VERSION\"" chart/Chart.yaml
+          # Verify mutation
+          ACTUAL=$(yq '.appVersion' chart/Chart.yaml)
+          if [[ "$ACTUAL" != "$VERSION" ]]; then
+            echo "::error::appVersion mismatch: expected $VERSION, got $ACTUAL"
+            exit 1
+          fi
+
+      - name: Package chart
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          helm package chart/ \
+            --version "$VERSION" \
+            --destination .helm-pkg/
+
+      - name: Push chart to ghcr.io
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          helm push ".helm-pkg/${{ env.CHART_NAME }}-${VERSION}.tgz" \
+            oci://${{ env.REGISTRY }}/yoda-digital/charts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Added
+
+- **Dockerfile** — multi-stage production build (`node:24-alpine`), non-root
+  user, read-only rootfs, security-context hardened.
+- **Helm chart** (`chart/`) — Kubernetes-ready deployment with ConfigMap,
+  Secret, ServiceAccount, PodDisruptionBudget, liveness/readiness probes
+  against `/healthz`, and support for `existingSecret`.
+  - Fail-loud guards: empty PAT token without `existingSecret` renders a
+    template error; PDB `minAvailable >= replicaCount` is caught at render
+    time to prevent drain deadlocks.
+  - New config values: `AUTH_MODE`, `USE_STREAMABLE_HTTP`,
+    `CORS_ALLOW_ORIGINS`, `HEALTHZ_MAX_SESSIONS` (from v0.4.0 features).
+- **GitHub Actions CI** (`.github/workflows/build.yml`) — three-job
+  pipeline: _validate_ (hadolint + helm lint + helm template), _docker_
+  (build & push via `docker/metadata-action`), _helm_ (package with
+  `--version` + OCI push). `:latest` tag only on semver releases; PRs run
+  validation only.
 
 ## [0.4.0] - 2026-05-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------------------------
+# GitLab MCP Server — Production Dockerfile
+# Multi-stage build for a minimal runtime image.
+# ---------------------------------------------------------------------------
+
+# -- Stage 1: build ----------------------------------------------------------
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+# Build TypeScript sources
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+
+# -- Stage 2: runtime --------------------------------------------------------
+FROM node:24-alpine
+
+WORKDIR /app
+
+# Install only production dependencies in runtime image
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+
+# Copy compiled server
+COPY --from=builder /app/dist ./dist
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    USE_SSE=true
+
+EXPOSE 3000
+
+# Run as non-root using built-in node user (uid 1000)
+RUN chown -R node:node /app
+USER node
+
+ENTRYPOINT ["node", "dist/index.js"]

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: gitlab-mcp
+description: Helm chart for the GitLab MCP Server
+type: application
+version: 0.1.0
+appVersion: "0.4.0"
+
+keywords:
+  - mcp
+  - gitlab
+  - devops
+
+home: https://github.com/yoda-digital/mcp-gitlab-server
+
+maintainers:
+  - name: Yoda Digital
+    url: https://github.com/yoda-digital

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,8 @@
+1. Get the application URL by running these commands:
+{{- if eq .Values.service.type "ClusterIP" }}
+  kubectl port-forward svc/{{ include "gitlab-mcp.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+  echo "MCP endpoint: http://localhost:{{ .Values.service.port }}/sse"
+{{- end }}
+
+2. In-cluster URL for MCP clients:
+   http://{{ include "gitlab-mcp.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/sse

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gitlab-mcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "gitlab-mcp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gitlab-mcp.labels" -}}
+helm.sh/chart: {{ include "gitlab-mcp.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "gitlab-mcp.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gitlab-mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gitlab-mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name
+*/}}
+{{- define "gitlab-mcp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gitlab-mcp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gitlab-mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "gitlab-mcp.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gitlab-mcp.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.PORT | default 3000 }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "gitlab-mcp.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret | default (include "gitlab-mcp.fullname" .) }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/chart/templates/pdb.yaml
+++ b/chart/templates/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.podDisruptionBudget .Values.podDisruptionBudget.enabled }}
+{{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
+  {{- fail "podDisruptionBudget: set EITHER minAvailable OR maxUnavailable, not both — Kubernetes rejects PDBs with both fields at apply time." }}
+{{- end }}
+{{- if and .Values.podDisruptionBudget.minAvailable (le (int .Values.replicaCount) (int .Values.podDisruptionBudget.minAvailable)) }}
+  {{- fail (printf "podDisruptionBudget.minAvailable (%d) >= replicaCount (%d) would deadlock node drains. Use maxUnavailable instead." (int .Values.podDisruptionBudget.minAvailable) (int .Values.replicaCount)) }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "gitlab-mcp.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.existingSecret .Values.secret.GITLAB_PERSONAL_ACCESS_TOKEN }}
+  {{- fail "Set EITHER existingSecret OR secret.GITLAB_PERSONAL_ACCESS_TOKEN, not both — the inline value would be silently ignored in favor of existingSecret." }}
+{{- end }}
+{{- if not .Values.existingSecret }}
+{{- if and (eq .Values.config.AUTH_MODE "pat") (not .Values.secret.GITLAB_PERSONAL_ACCESS_TOKEN) }}
+  {{- fail "secret.GITLAB_PERSONAL_ACCESS_TOKEN is required when AUTH_MODE=pat and no existingSecret is set." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secret }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gitlab-mcp.fullname" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gitlab-mcp.selectorLabels" . | nindent 4 }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gitlab-mcp.serviceAccountName" . }}
+  labels:
+    {{- include "gitlab-mcp.labels" . | nindent 4 }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,87 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/yoda-digital/mcp-gitlab-server
+  # -- Image tag. Overridden by CI at package time.
+  # Default "latest" is safe for local helm install; tagged releases use semver.
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+# -- GitLab MCP server configuration (non-sensitive)
+config:
+  PORT: "3000"
+  USE_SSE: "true"
+  USE_STREAMABLE_HTTP: "false"
+  GITLAB_API_URL: "https://gitlab.com/api/v4"
+  GITLAB_READ_ONLY_MODE: "false"
+  # -- Authentication mode: "pat" (default) or "oauth"
+  # "pat"   : static token from GITLAB_PERSONAL_ACCESS_TOKEN env var / existingSecret
+  # "oauth" : per-connection Bearer token forwarded in the Authorization header
+  AUTH_MODE: "pat"
+  # -- Comma-separated list of allowed CORS origins.
+  # In PAT mode: defaults to "*" if empty. In OAuth mode: no default (deny).
+  CORS_ALLOW_ORIGINS: ""
+  # -- Max sessions before /healthz returns 503 (default 10000)
+  HEALTHZ_MAX_SESSIONS: "10000"
+
+# -- Sensitive values injected as env vars from a Secret.
+# Set these or use existingSecret.
+secret:
+  GITLAB_PERSONAL_ACCESS_TOKEN: ""
+
+# -- Use an existing Secret instead of creating one.
+# The Secret must contain the keys listed in secret{} above.
+existingSecret: ""
+
+service:
+  type: ClusterIP
+  port: 3000
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# -- Extra env vars (list of {name, value} or {name, valueFrom})
+extraEnv: []
+
+# -- Extra envFrom (list of secretRef/configMapRef)
+extraEnvFrom: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- PodDisruptionBudget (recommended when replicaCount > 1).
+# NOTE: SSE/Streamable HTTP transports hold in-memory session state.
+# Multi-replica requires sticky sessions — see docs/OPERATIONS.md.
+podDisruptionBudget:
+  enabled: false
+  # maxUnavailable: 1 is the safe default — works at any replicaCount.
+  maxUnavailable: 1
+
+podAnnotations: {}
+podLabels: {}
+
+serviceAccount:
+  create: true
+  name: ""
+
+# -- Liveness / readiness probes
+probes:
+  liveness:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 30
+  readiness:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 3
+    periodSeconds: 10


### PR DESCRIPTION
Maintainer-rebased version of #29 with two additional fail-loud guards. All implementation work authored by @ecthelion77; rebase + guards by maintainer.

## Why a new PR (Path B)

Following the pattern established for #28 → #42: when main shifts during a contributor's review-response window, the maintainer-fair move is to take ownership of the rebase and any mechanical hardening rather than ask the contributor to redo work. PR #29 is opened from a fork branch (`forterro:feature/container-helm-chart`); to keep "everything in upstream," this PR re-bases onto current main inside `yoda-digital`'s upstream branch.

## What changed vs #29

The contributor's #29 update was already excellent — every must-fix and technical suggestion from the prior review was implemented. Two additional fail-loud guards added by maintainer:

1. **`chart/templates/secret.yaml`** — fail at template render if BOTH `existingSecret` AND inline `secret.GITLAB_PERSONAL_ACCESS_TOKEN` are set. Verified live: without this guard, `existingSecret` silently wins and the inline value is dropped, which costs hours of debugging when an operator copy-pastes from two examples.
2. **`chart/templates/pdb.yaml`** — fail at template render if BOTH `minAvailable` AND `maxUnavailable` are set. Kubernetes rejects PDBs with both fields at apply time; catching it at `helm template` time means you find out before the kubelet does.

Both are pure additions to the contributor's existing fail-loud-guard set (empty-token + replicaCount/minAvailable deadlock).

## Verification

Pulled into a worktree, ran the full local CI matrix:

| Check | Result |
| --- | --- |
| `hadolint Dockerfile` | clean |
| `helm lint chart/` | pass (only cosmetic INFO about `icon`) |
| `helm template` smoke (default + 6 fail-loud scenarios) | all behave correctly |
| `kubeconform -strict` on rendered manifests | 5/5 valid (Deployment, Service, ConfigMap, Secret, ServiceAccount) |
| `docker build .` | success, 216MB image |
| `docker run` + `curl /healthz` | HTTP 200 `{"status":"ok","sessions":0}` ✓ |
| `npm test` | 58/58 pass |

## Attribution

```
Author:    Olivier Gintrand <olivier.gintrand@forterro.com>
Committer: nalyk <dev.ungheni@gmail.com>
Subject:   feat: add Dockerfile, Helm chart, and CI/CD workflow
```

The squash-merge will carry a `Co-authored-by:` trailer for GitHub contribution-graph credit.

## Cross-PR coordination

- The `/healthz` endpoint already shipped in main via #42 (richer version with `HEALTHZ_MAX_SESSIONS` 503 trigger). No conflict — this PR's chart wires probes to that endpoint.
- The release-driven publish model from #43 governs npm publishes. This PR's `build.yml` governs container + Helm chart publishes (different registry: ghcr.io).

## Closes

Closes #29.

## Out of scope (tracked as follow-up issues)

The earlier review surfaced several operational concerns and quality items that are real but rare-event or future-looking. Each will become a tracked issue:

- Race / sequencing between `publish.yml` and `build.yml` on `release: published` events
- `/healthz` 503 wired to `livenessProbe` could trigger restart-loop at session overflow — needs `/livez` split in `transport.ts`
- `helm lint --set dummy-token` masks fail-loud guard regression (CI improvement)
- Tag-only push doesn't fire `publish.yml` (release ceremony documentation)
- First-publish ghcr permissions runbook
- Dockerfile improvements (`HEALTHCHECK`, `COPY --chown`, digest-pinned base, drop baked `USE_SSE=true` ENV)
- Action versions in `build.yml` lag behind `publish.yml` (`@v4` vs `@v6`) — Dependabot will normalize
- Multi-arch Docker build, SBOM, cosign, Trivy
- Helm chart polish: `chart/README.md`, `chart/values.schema.json`, helm-docs, `app.kubernetes.io/component`+`part-of` labels, `automountServiceAccountToken: false`, name-truncation collision handling
- `validate` job in `build.yml` to be added to the branch protection ruleset (separate API call accompanying this merge)