### PR TITLE
chart: add README.md, values.schema.json, and CI drift check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,19 @@ jobs:
             --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=dummy-for-lint \
             > /dev/null
 
+      - name: Install helm-docs
+        run: |
+          curl -sL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+            | tar xz -C /usr/local/bin helm-docs
+
+      - name: Check README drift (helm-docs)
+        run: |
+          helm-docs --chart-search-root chart/ --output-file README.md
+          git diff --exit-code chart/README.md || {
+            echo "::error::chart/README.md is out of date. Run 'helm-docs --chart-search-root chart/ --output-file README.md' and commit."
+            exit 1
+          }
+
   # -------------------------------------------------------------------
   # Job 2 — Docker build + push (skipped on PRs)
   # -------------------------------------------------------------------

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,96 @@
+# gitlab-mcp
+
+Helm chart for the GitLab MCP Server
+
+**Homepage:** <https://github.com/yoda-digital/mcp-gitlab-server>
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Helm 3.12+
+
+## Installing the chart
+
+```bash
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set secret.GITLAB_PERSONAL_ACCESS_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
+```
+
+### Using an existing Secret
+
+```bash
+kubectl create secret generic gitlab-mcp-token \
+  --from-literal=GITLAB_PERSONAL_ACCESS_TOKEN="glpat-xxxx"
+
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set existingSecret=gitlab-mcp-token
+```
+
+### OAuth mode (per-connection tokens)
+
+```bash
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set config.AUTH_MODE=oauth \
+  --set config.CORS_ALLOW_ORIGINS="https://my-app.example.com"
+```
+
+## Fail-loud guards
+
+The chart includes render-time validation:
+
+- **Empty PAT token** — fails if `AUTH_MODE=pat` with no token and no `existingSecret`.
+- **PDB deadlock** — fails if `minAvailable >= replicaCount` (would block node drains).
+- **Mutual exclusion** — fails if both `existingSecret` and inline `secret.GITLAB_PERSONAL_ACCESS_TOKEN` are set.
+
+## Multi-replica considerations
+
+SSE and Streamable HTTP transports hold in-memory session state. Running
+multiple replicas requires sticky sessions (e.g. session-affinity or an
+ingress controller with cookie-based routing). See
+[docs/OPERATIONS.md](../docs/OPERATIONS.md) for details.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| config | object | `{"AUTH_MODE":"pat","CORS_ALLOW_ORIGINS":"","GITLAB_API_URL":"https://gitlab.com/api/v4","GITLAB_READ_ONLY_MODE":"false","HEALTHZ_MAX_SESSIONS":"10000","PORT":"3000","USE_SSE":"true","USE_STREAMABLE_HTTP":"false"}` | GitLab MCP server configuration (non-sensitive) |
+| config.AUTH_MODE | string | `"pat"` | Authentication mode: "pat" (default) or "oauth" "pat"   : static token from GITLAB_PERSONAL_ACCESS_TOKEN env var / existingSecret "oauth" : per-connection Bearer token forwarded in the Authorization header |
+| config.CORS_ALLOW_ORIGINS | string | `""` | Comma-separated list of allowed CORS origins. In PAT mode: defaults to "*" if empty. In OAuth mode: no default (deny). |
+| config.HEALTHZ_MAX_SESSIONS | string | `"10000"` | Max sessions before /healthz returns 503 (default 10000) |
+| existingSecret | string | `""` | Use an existing Secret instead of creating one. The Secret must contain the keys listed in secret{} above. |
+| extraEnv | list | `[]` | Extra env vars (list of {name, value} or {name, valueFrom}) |
+| extraEnvFrom | list | `[]` | Extra envFrom (list of secretRef/configMapRef) |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"ghcr.io/yoda-digital/mcp-gitlab-server"` |  |
+| image.tag | string | `"latest"` | Image tag. Overridden by CI at package time. Default "latest" is safe for local helm install; tagged releases use semver. |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget (recommended when replicaCount > 1). NOTE: SSE/Streamable HTTP transports hold in-memory session state. Multi-replica requires sticky sessions — see docs/OPERATIONS.md. |
+| podLabels | object | `{}` |  |
+| probes | object | `{"liveness":{"enabled":true,"initialDelaySeconds":5,"path":"/healthz","periodSeconds":30},"readiness":{"enabled":true,"initialDelaySeconds":3,"path":"/healthz","periodSeconds":10}}` | Liveness / readiness probes |
+| replicaCount | int | `1` |  |
+| resources.limits.cpu | string | `"500m"` |  |
+| resources.limits.memory | string | `"256Mi"` |  |
+| resources.requests.cpu | string | `"50m"` |  |
+| resources.requests.memory | string | `"128Mi"` |  |
+| secret | object | `{"GITLAB_PERSONAL_ACCESS_TOKEN":""}` | Sensitive values injected as env vars from a Secret. Set these or use existingSecret. |
+| service.port | int | `3000` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
+
+## Uninstalling
+
+```bash
+helm uninstall gitlab-mcp
+```
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Yoda Digital |  | <https://github.com/yoda-digital> |

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -1,0 +1,60 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Helm 3.12+
+
+## Installing the chart
+
+```bash
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set secret.GITLAB_PERSONAL_ACCESS_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
+```
+
+### Using an existing Secret
+
+```bash
+kubectl create secret generic gitlab-mcp-token \
+  --from-literal=GITLAB_PERSONAL_ACCESS_TOKEN="glpat-xxxx"
+
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set existingSecret=gitlab-mcp-token
+```
+
+### OAuth mode (per-connection tokens)
+
+```bash
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
+  --set config.AUTH_MODE=oauth \
+  --set config.CORS_ALLOW_ORIGINS="https://my-app.example.com"
+```
+
+## Fail-loud guards
+
+The chart includes render-time validation:
+
+- **Empty PAT token** — fails if `AUTH_MODE=pat` with no token and no `existingSecret`.
+- **PDB deadlock** — fails if `minAvailable >= replicaCount` (would block node drains).
+- **Mutual exclusion** — fails if both `existingSecret` and inline `secret.GITLAB_PERSONAL_ACCESS_TOKEN` are set.
+
+## Multi-replica considerations
+
+SSE and Streamable HTTP transports hold in-memory session state. Running
+multiple replicas requires sticky sessions (e.g. session-affinity or an
+ingress controller with cookie-based routing). See
+[docs/OPERATIONS.md](../docs/OPERATIONS.md) for details.
+
+{{ template "chart.valuesSection" . }}
+
+## Uninstalling
+
+```bash
+helm uninstall gitlab-mcp
+```
+
+{{ template "chart.maintainersSection" . }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of pod replicas. Multi-replica requires sticky sessions."
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag. Overridden by CI at package time."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "config": {
+      "type": "object",
+      "description": "Non-sensitive environment variables injected via ConfigMap. Keys become env var names.",
+      "properties": {
+        "PORT": { "type": "string", "pattern": "^[0-9]+$" },
+        "USE_SSE": { "type": "string", "enum": ["true", "false"] },
+        "USE_STREAMABLE_HTTP": { "type": "string", "enum": ["true", "false"] },
+        "GITLAB_API_URL": { "type": "string", "format": "uri" },
+        "GITLAB_READ_ONLY_MODE": { "type": "string", "enum": ["true", "false"] },
+        "AUTH_MODE": {
+          "type": "string",
+          "enum": ["pat", "oauth"],
+          "description": "Authentication mode: 'pat' uses a static token, 'oauth' uses per-connection Bearer tokens."
+        },
+        "CORS_ALLOW_ORIGINS": {
+          "type": "string",
+          "description": "Comma-separated allowed CORS origins. Empty = '*' in PAT mode."
+        },
+        "HEALTHZ_MAX_SESSIONS": {
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "description": "Max sessions before /healthz returns 503."
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "secret": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Sensitive values injected via Secret. Required when AUTH_MODE=pat and no existingSecret.",
+      "properties": {
+        "GITLAB_PERSONAL_ACCESS_TOKEN": { "type": "string" }
+      }
+    },
+    "existingSecret": {
+      "type": "string",
+      "description": "Name of an existing Secret to use instead of creating one."
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Pod resource requests and limits.",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "description": "Extra env vars (list of {name, value} or {name, valueFrom}).",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": "string" },
+          "valueFrom": { "type": "object" }
+        }
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "description": "Extra envFrom (list of secretRef/configMapRef).",
+      "items": { "type": "object" }
+    },
+    "nodeSelector": { "type": "object" },
+    "tolerations": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "affinity": { "type": "object" },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": "integer", "minimum": 1 },
+        "maxUnavailable": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "liveness": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string" },
+            "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+            "periodSeconds": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "readiness": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string" },
+            "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+            "periodSeconds": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Addresses #50 — adds documentation and schema validation for the Helm chart.

## Changes

| File | Purpose |
|------|---------|
| `chart/README.md` | Generated from `values.yaml` annotations via [helm-docs](https://github.com/norwoodj/helm-docs) v1.14.2 |
| `chart/README.md.gotmpl` | Template for reproducible README generation |
| `chart/values.schema.json` | JSON Schema (draft 2020-12) for `helm lint` validation |
| `.github/workflows/build.yml` | CI step to detect README drift |

## PR checklist (from issue #50)

### Command used to generate README

```bash
helm-docs --chart-search-root chart/ --output-file README.md
```

Using helm-docs v1.14.2 with annotations already present in `values.yaml` (`# --` prefix).

### How schema was validated

- `helm lint chart/ --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=test` — passes with default values
- `helm lint chart/ --set typo=oops` — fails with `Additional property typo is not allowed`
- `helm lint chart/ --set config.CUSTOM_VAR=hello` — passes (config allows extra string keys)

### Which CI check protects against drift

New step **"Check README drift (helm-docs)"** in the `validate` job:
1. Installs helm-docs v1.14.2
2. Regenerates the README
3. Fails if `git diff --exit-code chart/README.md` detects changes

Schema validation is already covered by the existing `helm lint` step (Helm 3 natively validates against `values.schema.json` if present).

### additionalProperties: false — intentional use

- **Root level**: `additionalProperties: false` — catches typos in top-level value keys
- **`config{}`**: `additionalProperties: { "type": "string" }` — allows user-defined env vars but constrains them to strings (since they become ConfigMap entries)
- **Structural objects** (`image`, `service`, `secret`, `serviceAccount`, `probes`, `podDisruptionBudget`): `additionalProperties: false` — these have fixed schemas
- **Kubernetes-native objects** (`resources`, `nodeSelector`, `affinity`, `tolerations`, etc.): no restriction — follows upstream Kubernetes schema flexibility

Closes #50