### PR TITLE
chore(release): 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet. New entries land here between releases._
 
+## [0.5.1] - 2026-05-05
+
+Documentation patch release. No functional code changes from 0.5.0; the
+npm package republishes solely to refresh the README displayed on the
+npm package page (npm freezes the README to whatever ships in the
+publish tarball, so an updated README requires a new version).
+
+### Documentation
+
+- **README rewrite (#54)** — replaces the 0.3-era marketing-style README.
+  New version covers what shipped in 0.4.0 / 0.5.0: 86 tools, three
+  transports (stdio / SSE / Streamable HTTP), PAT and OAuth modes,
+  Docker plus Helm with fail-loud guards, supply-chain posture, and
+  contributor credits for PR #42 and PR #44.
+- **Tool-surface accuracy** — bullets aligned with current `src/index.ts`:
+  dropped `archive` (no such tool); corrected CRUD claims for issues,
+  labels, milestones, and protected branches.
+- **Doc layout** — `CURSOR_INTEGRATION.md` moved to `docs/` (links
+  updated); removed `README-old.md`, `AGENTS.md`, and `tools/`.
+
 ## [0.5.0] - 2026-05-04
 
 A packaging and operations release: container image, Helm chart, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Documentation patch release. No functional code changes from 0.5.0.

The 0.5.0 publish tarball carried the old (0.3-era marketing-style) README. npm freezes the README to whatever ships at publish time — there's no GitHub→npm sync — so the corrected README from #54 won't appear on the npm package page until a new version is published. This release is purely to make that happen.

## Changes

- `package.json` `version` 0.5.0 → 0.5.1
- `CHANGELOG.md` 0.5.1 dated section added (Documentation: README rewrite, tool-surface accuracy fixes, doc-tree cleanup)
- `package-lock.json` root version synced (was lagging at 0.4.0 from a prior release)

## Post-merge

Create GitHub Release `v0.5.1` referencing the new CHANGELOG section. `publish.yml` triggers on the release event and runs the npm OIDC trusted-publish step with Sigstore provenance.

## Test plan

- [x] `npm test` (58 tests passing)
- [x] CI gates: `build-and-test`, `validate`, CodeQL — runs on this PR