### PR TITLE
ci(chart): add negative tests for fail-loud guards in validate job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,65 @@ jobs:
             --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=dummy-for-lint \
             > /dev/null
 
+      - name: Negative tests — fail-loud guards
+        run: |
+          set +e
+          FAIL=0
+          run_negative() {
+            local name="$1"; local expected="$2"; shift 2
+            OUT=$(helm template t chart/ "$@" 2>&1)
+            RC=$?
+            if [[ $RC -eq 0 ]]; then
+              echo "::error::$name: expected failure, got success"
+              FAIL=1; return
+            fi
+            if ! grep -qi "$expected" <<< "$OUT"; then
+              echo "::error::$name: expected message '$expected' not in output"
+              echo "::error::$name: actual output: $OUT"
+              FAIL=1; return
+            fi
+            echo "::notice::$name OK"
+          }
+
+          # Guard 1: empty PAT in pat mode without existingSecret
+          run_negative "empty-pat-token" "GITLAB_PERSONAL_ACCESS_TOKEN is required when AUTH_MODE=pat" \
+            --set config.AUTH_MODE=pat \
+            --set config.HOST=127.0.0.1 \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=""
+
+          # Guard 2: PDB minAvailable >= replicaCount (deadlock)
+          run_negative "pdb-deadlock" "would deadlock node drains" \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=ok \
+            --set podDisruptionBudget.enabled=true \
+            --set podDisruptionBudget.minAvailable=1 \
+            --set podDisruptionBudget.maxUnavailable=null \
+            --set replicaCount=1
+
+          # Guard 3: both existingSecret and inline token
+          run_negative "secret-conflict" "Set EITHER existingSecret OR secret.GITLAB_PERSONAL_ACCESS_TOKEN" \
+            --set existingSecret=my-secret \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=tok
+
+          # Guard 4: PDB both minAvailable and maxUnavailable
+          run_negative "pdb-both-fields" "set EITHER minAvailable OR maxUnavailable" \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=ok \
+            --set podDisruptionBudget.enabled=true \
+            --set podDisruptionBudget.minAvailable=1 \
+            --set podDisruptionBudget.maxUnavailable=1
+
+          # Guard 5: invalid AUTH_MODE (rejected by values.schema.json)
+          run_negative "invalid-auth-mode" "values don't meet the specifications" \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=ok \
+            --set config.AUTH_MODE=invalid
+
+          # Guard 6: PAT mode on non-loopback host (GHSA-8jr5-6gvj-rfpf)
+          run_negative "pat-non-loopback" "AUTH_MODE=pat requires HOST" \
+            --set config.AUTH_MODE=pat \
+            --set config.HOST=0.0.0.0 \
+            --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=ok
+
+          if [[ $FAIL -ne 0 ]]; then exit 1; fi
+
       - name: Install helm-docs
         run: |
           curl -sL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Added
+
+- **CI: negative tests for chart fail-loud guards (#48)** — the `validate`
+  job now runs `helm template` with six deliberately broken value sets and
+  asserts each guard fires (non-zero exit + expected error substring).
+  Includes the new `auth-validation.yaml` guard from #58 (GHSA-8jr5-6gvj-rfpf).
+- `chart/values.yaml` documentation comment block listing all six guards,
+  their source template, and the CI-matched error substring.
 
 ## [0.6.0] - 2026-05-05
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,22 @@
 replicaCount: 1
 
+# ===========================================================================
+# Fail-loud guards
+# ===========================================================================
+# The chart templates include validation guards that abort with a clear error
+# message when values are misconfigured. CI runs negative tests to ensure
+# these guards are not accidentally removed during refactoring.
+#
+#   Guard                    Template              Expected error substring
+#   ~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   Empty PAT in pat mode    secret.yaml           GITLAB_PERSONAL_ACCESS_TOKEN is required when AUTH_MODE=pat
+#   PDB deadlock             pdb.yaml              would deadlock node drains
+#   Secret conflict          secret.yaml           Set EITHER existingSecret OR secret.GITLAB_PERSONAL_ACCESS_TOKEN
+#   PDB both fields          pdb.yaml              set EITHER minAvailable OR maxUnavailable
+#   Invalid AUTH_MODE        schema.json           values don't meet the specifications
+#   PAT non-loopback host    auth-validation.yaml  AUTH_MODE=pat requires HOST
+# ===========================================================================
+
 image:
   repository: ghcr.io/yoda-digital/mcp-gitlab-server
   # -- Image tag. Overridden by CI at package time.


### PR DESCRIPTION
## Summary

Adds a **"Negative tests — fail-loud guards"** step to the `validate` job in `.github/workflows/build.yml` that exercises all five chart guards with deliberately broken inputs. Each test asserts both a non-zero exit code and the expected error substring in the output.

## Guards covered

| # | Test name | Guard | Template / schema | Trigger |
|---|-----------|-------|-------------------|---------|
| 1 | `empty-pat-token` | Empty PAT in pat mode | `secret.yaml` | `--set secret.GITLAB_PERSONAL_ACCESS_TOKEN=""` |
| 2 | `pdb-deadlock` | minAvailable ≥ replicaCount | `pdb.yaml` | `minAvailable=1, replicaCount=1` |
| 3 | `secret-conflict` | Both existingSecret and inline PAT | `secret.yaml` | `existingSecret=foo` + `PAT=tok` |
| 4 | `pdb-both-fields` | Both minAvailable and maxUnavailable | `pdb.yaml` | Both set to 1 |
| 5 | `invalid-auth-mode` | Invalid AUTH_MODE | `values.schema.json` | `AUTH_MODE=invalid` |

## Changes

- `.github/workflows/build.yml` — new step after `Helm template smoke test`, before `Install helm-docs`
- `chart/values.yaml` — documentation comment block listing all guards + their error substrings

## Validation

- **CI tested on fork** — [run 25388453083](https://github.com/forterro/mcp-gitlab-server/actions/runs/25388453083) passed all steps including the new negative tests
- `helm-docs` regenerated: no README drift (verified with `helm-docs --check`)
- All 5 negative tests pass locally on Helm v3.17.3
- Positive `helm lint` / `helm template` still pass

## Notes

- The `run_negative` helper uses `set +e` to capture exit codes and `grep -qi` for case-insensitive substring matching
- Guard 2 requires `--set podDisruptionBudget.maxUnavailable=null` to clear the default from `values.yaml`
- Guard 5 is enforced by `values.schema.json` (enum constraint), not a template `fail` call

Closes #48