### PR TITLE
fix(security): require auth or loopback bind for HTTP transports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,24 @@
-# Required
+# Required (PAT mode only — see AUTH_MODE below)
 GITLAB_PERSONAL_ACCESS_TOKEN=
 
-# Optional
+# Transport / bind
 GITLAB_API_URL=https://gitlab.com/api/v4
 PORT=3000
+# HOST defaults to 127.0.0.1 (loopback only). Set to 0.0.0.0 to expose to
+# the network — but only with AUTH_MODE=oauth, otherwise startup refuses.
+HOST=127.0.0.1
 USE_SSE=false
+USE_STREAMABLE_HTTP=false
+
+# Auth
+# AUTH_MODE=pat   — single static GITLAB_PERSONAL_ACCESS_TOKEN; loopback only.
+# AUTH_MODE=oauth — per-connection Authorization: Bearer; required for any
+#                   network-exposed bind (HOST != 127.0.0.1).
+AUTH_MODE=pat
+
+# Misc
 GITLAB_READ_ONLY_MODE=false
+# Empty defaults to '*' only when AUTH_MODE=pat AND bind is loopback.
+# Network-exposed binds need an explicit comma-separated allowlist.
+CORS_ALLOW_ORIGINS=
+HEALTHZ_MAX_SESSIONS=10000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ Security release. Closes [GHSA-8jr5-6gvj-rfpf](https://github.com/yoda-digital/m
 
 ### Security
 
-- **Sessions bound to originating Bearer (CWE-287).** OAuth-mode sessions store the SHA-256 hash of the `Authorization: Bearer` that opened them. Every subsequent request reusing the `MCP-Session-Id` (or SSE `sessionId` query param) must present the same Bearer; a leaked sessionId without the original token is rejected with 401.
+- **Sessions bound to originating Bearer (CWE-287).** OAuth-mode sessions store the SHA-256 hash of the `Authorization: Bearer` that opened them. Every subsequent request reusing the `MCP-Session-Id` (or SSE `sessionId` query param) must present the same Bearer; a leaked sessionId without the original token is rejected with 401. Comparison uses `crypto.timingSafeEqual` to prevent a timing-oracle attack against the stored hash.
 - **Defense-in-depth: `setupTransport` itself refuses to start an unsafe combination**, even if a caller bypasses the `index.ts` startup guard. Same check, two layers.
+- **Loopback detection covers the full IPv4 `127.0.0.0/8` range** (not just `127.0.0.1`), plus `::1`, `::ffff:127.x.y.z`, and case-insensitive `localhost`. Operators who pick a non-`127.0.0.1` loopback address for port-conflict reasons are still safe; the safety guard correctly identifies them as loopback.
 - **CORS-on-loopback-only.** Wildcard origin is permitted only when bind is loopback AND `AUTH_MODE=pat` AND `CORS_ALLOW_ORIGINS` is empty. Any other configuration requires an explicit allowlist.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet. New entries land here between releases._
 
+## [0.6.0] - 2026-05-05
+
+Security release. Closes [GHSA-8jr5-6gvj-rfpf](https://github.com/yoda-digital/mcp-gitlab-server/security/advisories/GHSA-8jr5-6gvj-rfpf) — SSE / Streamable HTTP transports were unauthenticated in default (PAT) mode and bound to all interfaces, exposing all 86 GitLab tools (including write tools) to anyone reachable on the bind. Reported privately by [@dodge1218](https://github.com/dodge1218).
+
+### Breaking changes
+
+- **`HOST` defaults to `127.0.0.1`** (loopback only) for HTTP transports. Set `HOST=0.0.0.0` (or a specific interface) to expose to the network — but only with `AUTH_MODE=oauth`, otherwise startup refuses.
+- **`AUTH_MODE=pat` + non-loopback bind is refused at startup.** The server exits with a fatal error naming the env vars to set. Either bind loopback for local dev, or switch to OAuth mode for shared deployments.
+- **Helm chart `config.AUTH_MODE` default flipped from `pat` to `oauth`.** Pods are reachable via the Kubernetes Service, which is cluster-reachable by design — PAT mode in Helm was the documented vulnerable configuration. A new `chart/templates/auth-validation.yaml` guard refuses install when `AUTH_MODE=pat` is combined with a non-loopback `HOST`.
+- **Wildcard `Access-Control-Allow-Origin: *` is no longer emitted on non-loopback binds**, regardless of `AUTH_MODE`. Network-exposed deployments must set `CORS_ALLOW_ORIGINS` explicitly.
+
+### Security
+
+- **Sessions bound to originating Bearer (CWE-287).** OAuth-mode sessions store the SHA-256 hash of the `Authorization: Bearer` that opened them. Every subsequent request reusing the `MCP-Session-Id` (or SSE `sessionId` query param) must present the same Bearer; a leaked sessionId without the original token is rejected with 401.
+- **Defense-in-depth: `setupTransport` itself refuses to start an unsafe combination**, even if a caller bypasses the `index.ts` startup guard. Same check, two layers.
+- **CORS-on-loopback-only.** Wildcard origin is permitted only when bind is loopback AND `AUTH_MODE=pat` AND `CORS_ALLOW_ORIGINS` is empty. Any other configuration requires an explicit allowlist.
+
+### Added
+
+- New `HOST` environment variable (default `127.0.0.1`).
+- New `chart/templates/auth-validation.yaml` fail-loud guard.
+- New exported helpers in `src/transport.ts`: `isLoopbackHost(host)`, `requireSafeTransportConfig({useSSE, useStreamableHttp, host, authMode})`.
+- New `## Threat model — auth × bind matrix` section in `SECURITY.md`.
+- Tests covering startup-config refusal, sessionId-Bearer binding rejection (wrong Bearer, no Bearer), and the `setupTransport` defense-in-depth path.
+
+### Migration
+
+- **Local stdio clients (Claude Desktop, Cursor, Zed):** no change. Stdio is unaffected.
+- **Local HTTP for development:** no change if you bind loopback (the new default). If your previous setup relied on `0.0.0.0` for cross-machine local-dev access, set `HOST=127.0.0.1` (default) for single-machine, or switch to `AUTH_MODE=oauth` and front it with a gateway.
+- **Docker `docker run -p 3000:3000`:** the in-container bind defaults to `127.0.0.1`, which is not reachable through the port mapping. Set `HOST=0.0.0.0` *and* `AUTH_MODE=oauth`. Update your client URLs to go through your gateway.
+- **Helm `helm install`:** the chart defaults to `AUTH_MODE=oauth` and `HOST=0.0.0.0`. If you were depending on the previous PAT default, the chart's auth-validation guard will refuse install — set `config.AUTH_MODE=oauth` and front the Service with an Ingress that injects `Authorization: Bearer`.
+
+### Credits
+
+[@dodge1218](https://github.com/dodge1218) for the responsible disclosure, the reproducible PoC, the CWE mapping, and the design conversation on the patch shape.
+
 ## [0.5.1] - 2026-05-05
 
 Documentation patch release. No functional code changes from 0.5.0; the

--- a/README.md
+++ b/README.md
@@ -81,18 +81,19 @@ For Claude Desktop, Cursor, Zed, and any client that runs MCP servers as a local
 
 Self-hosted? Replace `GITLAB_API_URL` with your instance, e.g. `https://gitlab.example.com/api/v4`. Want a safe demo with no write access? Add `"GITLAB_READ_ONLY_MODE": "true"`. Per-IDE notes are in [`docs/CURSOR_INTEGRATION.md`](./docs/CURSOR_INTEGRATION.md).
 
-### Remote (Streamable HTTP)
+### Remote (Streamable HTTP, OAuth-gated)
 
-For shared deployments and modern remote MCP clients, run the server as an HTTP service:
+For shared deployments and modern remote MCP clients, run the server as an HTTP service. Network-exposed deployments require `AUTH_MODE=oauth` — the server refuses to start with `AUTH_MODE=pat` on a non-loopback bind. See [`SECURITY.md`](./SECURITY.md) for the threat model.
 
 ```bash
 docker run --rm -p 3000:3000 \
-  -e GITLAB_PERSONAL_ACCESS_TOKEN=glpat-… \
+  -e HOST=0.0.0.0 \
+  -e AUTH_MODE=oauth \
   -e USE_STREAMABLE_HTTP=true \
   ghcr.io/yoda-digital/mcp-gitlab-server:latest
 ```
 
-Then point clients at `http://localhost:3000/mcp`. For per-connection OAuth, where each user supplies their own Bearer token, set `AUTH_MODE=oauth` and front the server with a gateway that injects `Authorization: Bearer <token>`.
+Then front the container with a gateway that injects `Authorization: Bearer <token>` per connection — the server forwards that Bearer to GitLab as the per-connection PAT. Point clients at `http://your-gateway/mcp`.
 
 Operational details, probe configuration, and troubleshooting are in [`docs/OPERATIONS.md`](./docs/OPERATIONS.md).
 
@@ -133,11 +134,11 @@ Streamable HTTP runs `POST /mcp`, `GET /mcp`, and `DELETE /mcp`, with session ma
 
 ## Authentication
 
-Two modes. Pick the one that matches your deployment.
+Two modes. The right one depends on whether the HTTP transport is reachable from the network.
 
-PAT mode (the default). The server holds one personal access token in `GITLAB_PERSONAL_ACCESS_TOKEN`. Simple, and the right choice for almost everyone running this locally or as a single-tenant service.
+OAuth per connection (`AUTH_MODE=oauth`, the default for network-exposed deployments). The server holds no static token. Every MCP connection brings its own `Authorization: Bearer <token>`, which the server forwards to GitLab as the effective PAT for that connection. Run it behind a gateway that handles your IdP. This is how you operate one shared deployment for an entire team. Required whenever bind is non-loopback.
 
-OAuth per connection (`AUTH_MODE=oauth`). The server holds nothing. Every MCP connection brings its own `Authorization: Bearer <token>`, which the server forwards to GitLab. Run it behind a gateway that handles your IdP. This is how you operate one shared deployment for an entire team.
+PAT mode (`AUTH_MODE=pat`, loopback only). The server holds one personal access token in `GITLAB_PERSONAL_ACCESS_TOKEN`. The HTTP transport runs **without authentication** in this mode, so the server enforces a loopback-only bind (`HOST=127.0.0.1`) and refuses to start otherwise. Right choice for stdio clients and single-tenant local dev. Not supported in Helm — see the chart's auth-validation guard.
 
 ---
 
@@ -148,11 +149,12 @@ OAuth per connection (`AUTH_MODE=oauth`). The server holds nothing. Every MCP co
 | `GITLAB_PERSONAL_ACCESS_TOKEN` | — | Required in PAT mode. |
 | `GITLAB_API_URL` | `https://gitlab.com/api/v4` | GitLab API base URL. Point at your self-hosted instance if needed. |
 | `GITLAB_READ_ONLY_MODE` | `false` | Hide all write tools. |
-| `AUTH_MODE` | `pat` | `pat` or `oauth`. |
+| `AUTH_MODE` | `pat` | `pat` (loopback only) or `oauth` (any bind). |
+| `HOST` | `127.0.0.1` | Bind address for HTTP transports. Set to `0.0.0.0` to expose to the network — but only with `AUTH_MODE=oauth`, otherwise startup refuses. |
 | `USE_SSE` | `false` | Enable legacy SSE transport. |
 | `USE_STREAMABLE_HTTP` | `false` | Enable MCP Streamable HTTP transport. |
 | `PORT` | `3000` | HTTP listen port for SSE and Streamable HTTP. |
-| `CORS_ALLOW_ORIGINS` | _(empty)_ | Comma-separated allowlist. Empty means `*` in PAT mode and deny in OAuth mode. |
+| `CORS_ALLOW_ORIGINS` | _(empty)_ | Comma-separated allowlist. Empty means `*` in PAT-loopback mode (local dev only); empty in OAuth mode means deny. Wildcard is never emitted on a non-loopback bind. |
 | `HEALTHZ_MAX_SESSIONS` | `10000` | `/healthz` flips to 503 above this threshold. |
 
 `.env.example` ships in the repo for local development.
@@ -172,12 +174,14 @@ Multi-stage build on `node:24-alpine`. Runs as non-root (uid 1000) with all capa
 ### Kubernetes (Helm)
 
 ```bash
-helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp \
-  --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=glpat-…
+helm install gitlab-mcp oci://ghcr.io/yoda-digital/charts/gitlab-mcp
 ```
 
-The chart ships liveness and readiness probes against `/healthz`, an optional `PodDisruptionBudget`, ConfigMap and Secret with rolling-restart annotations, and four fail-loud guards that refuse to render bad configurations:
+The chart defaults to `AUTH_MODE=oauth` so a vanilla install is auth-gated. Front the Service with an Ingress or gateway that injects `Authorization: Bearer <token>` per connection.
 
+The chart ships liveness and readiness probes against `/healthz`, an optional `PodDisruptionBudget`, ConfigMap and Secret with rolling-restart annotations, and five fail-loud guards that refuse to render bad configurations:
+
+- `AUTH_MODE=pat` with non-loopback `HOST` (CWE-306 — see `chart/templates/auth-validation.yaml`)
 - empty PAT in PAT mode without `existingSecret`
 - both `existingSecret` and inline `secret.GITLAB_PERSONAL_ACCESS_TOKEN` set (a silent precedence trap, otherwise)
 - `PDB minAvailable >= replicaCount` (drain deadlock)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ properties are a function of two axes:
 
 | `AUTH_MODE` | `HOST` (bind) | Outcome |
 |---|---|---|
-| `pat` | `127.0.0.1` (loopback) | OK for single-tenant local dev. Wildcard CORS permitted. No network exposure. |
+| `pat` | `127.0.0.0/8` IP literal (loopback) | OK for single-tenant local dev. Wildcard CORS permitted. No network exposure. |
 | `pat` | non-loopback | **Refused at startup.** Unauthenticated network exposure of a PAT-backed GitLab tool surface (CWE-306). |
 | `oauth` | `127.0.0.1` (loopback) | OK. `Authorization: Bearer` required on every request. |
 | `oauth` | non-loopback | OK for shared deployments. Front with a gateway that handles your IdP and injects `Authorization: Bearer`. |
@@ -35,6 +35,12 @@ CORS: the wildcard `Access-Control-Allow-Origin: *` is emitted only on
 the loopback-PAT-empty-allowlist combination. Network-exposed binds
 require an explicit `CORS_ALLOW_ORIGINS` allowlist; otherwise no
 `Allow-Origin` header is set and browsers refuse cross-origin reads.
+
+Note on hostnames: the loopback check accepts the literal name
+`localhost` (case-insensitive) but does **not** resolve it through
+DNS or `/etc/hosts`. For hardening configurations, prefer the IP
+literal `127.0.0.1` — the literal can't be redirected by a hosts-file
+mistake or a downstream resolver to a non-loopback address.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,33 @@ Report security vulnerabilities **privately** via GitHub's
 Expected response time: best-effort within 7 days. Coordinated disclosure
 preferred.
 
+## Threat model — auth × bind matrix
+
+The HTTP transports (`USE_SSE`, `USE_STREAMABLE_HTTP`) carry no
+authentication of their own in `AUTH_MODE=pat`. The server's safety
+properties are a function of two axes:
+
+| `AUTH_MODE` | `HOST` (bind) | Outcome |
+|---|---|---|
+| `pat` | `127.0.0.1` (loopback) | OK for single-tenant local dev. Wildcard CORS permitted. No network exposure. |
+| `pat` | non-loopback | **Refused at startup.** Unauthenticated network exposure of a PAT-backed GitLab tool surface (CWE-306). |
+| `oauth` | `127.0.0.1` (loopback) | OK. `Authorization: Bearer` required on every request. |
+| `oauth` | non-loopback | OK for shared deployments. Front with a gateway that handles your IdP and injects `Authorization: Bearer`. |
+
+The Helm chart defaults to `AUTH_MODE=oauth` because a Kubernetes
+Service is by definition cluster-reachable, which means non-loopback
+bind. A chart-level `{{ fail }}` guard refuses install if PAT mode is
+combined with a network-exposed `HOST`.
+
+OAuth-mode sessions are bound to the SHA-256 hash of their originating
+`Authorization: Bearer` header; a leaked `MCP-Session-Id` without the
+original Bearer is rejected with 401.
+
+CORS: the wildcard `Access-Control-Allow-Origin: *` is emitted only on
+the loopback-PAT-empty-allowlist combination. Network-exposed binds
+require an explicit `CORS_ALLOW_ORIGINS` allowlist; otherwise no
+`Allow-Origin` header is set and browsers refuse cross-origin reads.
+
 ## Scope
 
 This server connects to a GitLab instance using a personal access token

--- a/chart/README.md
+++ b/chart/README.md
@@ -54,10 +54,11 @@ ingress controller with cookie-based routing). See
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| config | object | `{"AUTH_MODE":"pat","CORS_ALLOW_ORIGINS":"","GITLAB_API_URL":"https://gitlab.com/api/v4","GITLAB_READ_ONLY_MODE":"false","HEALTHZ_MAX_SESSIONS":"10000","PORT":"3000","USE_SSE":"true","USE_STREAMABLE_HTTP":"false"}` | GitLab MCP server configuration (non-sensitive) |
-| config.AUTH_MODE | string | `"pat"` | Authentication mode: "pat" (default) or "oauth" "pat"   : static token from GITLAB_PERSONAL_ACCESS_TOKEN env var / existingSecret "oauth" : per-connection Bearer token forwarded in the Authorization header |
-| config.CORS_ALLOW_ORIGINS | string | `""` | Comma-separated list of allowed CORS origins. In PAT mode: defaults to "*" if empty. In OAuth mode: no default (deny). |
+| config | object | `{"AUTH_MODE":"oauth","CORS_ALLOW_ORIGINS":"","GITLAB_API_URL":"https://gitlab.com/api/v4","GITLAB_READ_ONLY_MODE":"false","HEALTHZ_MAX_SESSIONS":"10000","HOST":"0.0.0.0","PORT":"3000","USE_SSE":"true","USE_STREAMABLE_HTTP":"false"}` | GitLab MCP server configuration (non-sensitive) |
+| config.AUTH_MODE | string | `"oauth"` | Authentication mode: "oauth" (default) or "pat" "oauth" : per-connection Bearer token forwarded in the Authorization header.           This is the only safe mode for cluster-reachable Service exposure. "pat"   : static token from GITLAB_PERSONAL_ACCESS_TOKEN env var / existingSecret.           UNSUPPORTED in Helm — the chart-level guard refuses install because           pods are reachable via Kubernetes Service, which violates the           loopback-only constraint of PAT mode (GHSA-8jr5-6gvj-rfpf). |
+| config.CORS_ALLOW_ORIGINS | string | `""` | Comma-separated list of allowed CORS origins. In PAT-loopback mode: defaults to "*" if empty (local dev only). In OAuth mode: no default (deny browser cross-origin access). |
 | config.HEALTHZ_MAX_SESSIONS | string | `"10000"` | Max sessions before /healthz returns 503 (default 10000) |
+| config.HOST | string | `"0.0.0.0"` | Bind address. Pods must bind to all interfaces for the Service to reach them, so the chart sets HOST=0.0.0.0. Combined with AUTH_MODE=oauth below, network exposure is auth-gated. The application's own default is HOST=127.0.0.1 (loopback) for non-Helm local-dev safety. |
 | existingSecret | string | `""` | Use an existing Secret instead of creating one. The Secret must contain the keys listed in secret{} above. |
 | extraEnv | list | `[]` | Extra env vars (list of {name, value} or {name, valueFrom}) |
 | extraEnvFrom | list | `[]` | Extra envFrom (list of secretRef/configMapRef) |

--- a/chart/templates/auth-validation.yaml
+++ b/chart/templates/auth-validation.yaml
@@ -8,14 +8,19 @@ must bind to 0.0.0.0 for the Service to route to it, PAT mode is
 unauthenticated network exposure — exactly the configuration described
 in advisory GHSA-8jr5-6gvj-rfpf.
 
-If an operator explicitly opts into PAT mode (e.g. for a single-node
-cluster with sticky-session ingress that handles auth upstream), they
-must also explicitly bind loopback (HOST=127.0.0.1), which makes the pod
-unreachable via a normal Service — a deliberate "are you sure" friction.
+The loopback check matches the runtime check in src/transport.ts:
+covers the full IPv4 loopback range (127.0.0.0/8 — 127.x.y.z), the IPv6
+loopback ::1, and the case-insensitive hostname `localhost`. A naive
+equality check on `127.0.0.1` alone would have missed an operator
+binding to 127.5.6.7 for port-conflict reasons.
 */ -}}
 {{- if eq .Values.config.AUTH_MODE "pat" }}
   {{- $host := .Values.config.HOST | default "0.0.0.0" }}
-  {{- if and (ne $host "127.0.0.1") (ne $host "::1") (ne $host "localhost") }}
-    {{- fail (printf "AUTH_MODE=pat requires HOST=127.0.0.1 (loopback). Current HOST=%q would expose an unauthenticated GitLab tool surface to anyone who can reach the pod (CWE-306). Set config.AUTH_MODE=oauth and front the Service with a gateway that injects Authorization: Bearer, or set config.HOST=127.0.0.1 if you accept the loopback-only Service trade-off." $host) }}
+  {{- $isLoopback := false }}
+  {{- if regexMatch "^127\\.[0-9]+\\.[0-9]+\\.[0-9]+$" $host }}{{- $isLoopback = true }}{{- end }}
+  {{- if eq $host "::1" }}{{- $isLoopback = true }}{{- end }}
+  {{- if regexMatch "(?i)^localhost$" $host }}{{- $isLoopback = true }}{{- end }}
+  {{- if not $isLoopback }}
+    {{- fail (printf "AUTH_MODE=pat requires HOST in the 127.0.0.0/8 loopback range (or ::1, or localhost). Current HOST=%q would expose an unauthenticated GitLab tool surface to anyone who can reach the pod (CWE-306). Set config.AUTH_MODE=oauth and front the Service with a gateway that injects Authorization: Bearer, or set config.HOST=127.0.0.1 if you accept the loopback-only Service trade-off." $host) }}
   {{- end }}
 {{- end }}

--- a/chart/templates/auth-validation.yaml
+++ b/chart/templates/auth-validation.yaml
@@ -1,0 +1,21 @@
+{{- /*
+Fail-loud guard for AUTH_MODE=pat in Helm deployments.
+
+Pods running this chart are reachable via the Kubernetes Service (and
+potentially via Ingress/LoadBalancer). PAT mode treats the HTTP transport
+as unauthenticated and is safe only on a loopback bind. Inside a pod that
+must bind to 0.0.0.0 for the Service to route to it, PAT mode is
+unauthenticated network exposure — exactly the configuration described
+in advisory GHSA-8jr5-6gvj-rfpf.
+
+If an operator explicitly opts into PAT mode (e.g. for a single-node
+cluster with sticky-session ingress that handles auth upstream), they
+must also explicitly bind loopback (HOST=127.0.0.1), which makes the pod
+unreachable via a normal Service — a deliberate "are you sure" friction.
+*/ -}}
+{{- if eq .Values.config.AUTH_MODE "pat" }}
+  {{- $host := .Values.config.HOST | default "0.0.0.0" }}
+  {{- if and (ne $host "127.0.0.1") (ne $host "::1") (ne $host "localhost") }}
+    {{- fail (printf "AUTH_MODE=pat requires HOST=127.0.0.1 (loopback). Current HOST=%q would expose an unauthenticated GitLab tool surface to anyone who can reach the pod (CWE-306). Set config.AUTH_MODE=oauth and front the Service with a gateway that injects Authorization: Bearer, or set config.HOST=127.0.0.1 if you accept the loopback-only Service trade-off." $host) }}
+  {{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -33,6 +33,10 @@
       "description": "Non-sensitive environment variables injected via ConfigMap. Keys become env var names.",
       "properties": {
         "PORT": { "type": "string", "pattern": "^[0-9]+$" },
+        "HOST": {
+          "type": "string",
+          "description": "Bind address. The chart sets '0.0.0.0' by default so the Kubernetes Service can route to the pod. Combined with AUTH_MODE=oauth (default) this is auth-gated. Setting AUTH_MODE=pat requires HOST=127.0.0.1 — see chart/templates/auth-validation.yaml."
+        },
         "USE_SSE": { "type": "string", "enum": ["true", "false"] },
         "USE_STREAMABLE_HTTP": { "type": "string", "enum": ["true", "false"] },
         "GITLAB_API_URL": { "type": "string", "format": "uri" },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,16 +13,26 @@ fullnameOverride: ""
 # -- GitLab MCP server configuration (non-sensitive)
 config:
   PORT: "3000"
+  # -- Bind address. Pods must bind to all interfaces for the Service to
+  # reach them, so the chart sets HOST=0.0.0.0. Combined with AUTH_MODE=oauth
+  # below, network exposure is auth-gated. The application's own default is
+  # HOST=127.0.0.1 (loopback) for non-Helm local-dev safety.
+  HOST: "0.0.0.0"
   USE_SSE: "true"
   USE_STREAMABLE_HTTP: "false"
   GITLAB_API_URL: "https://gitlab.com/api/v4"
   GITLAB_READ_ONLY_MODE: "false"
-  # -- Authentication mode: "pat" (default) or "oauth"
-  # "pat"   : static token from GITLAB_PERSONAL_ACCESS_TOKEN env var / existingSecret
-  # "oauth" : per-connection Bearer token forwarded in the Authorization header
-  AUTH_MODE: "pat"
+  # -- Authentication mode: "oauth" (default) or "pat"
+  # "oauth" : per-connection Bearer token forwarded in the Authorization header.
+  #           This is the only safe mode for cluster-reachable Service exposure.
+  # "pat"   : static token from GITLAB_PERSONAL_ACCESS_TOKEN env var / existingSecret.
+  #           UNSUPPORTED in Helm — the chart-level guard refuses install because
+  #           pods are reachable via Kubernetes Service, which violates the
+  #           loopback-only constraint of PAT mode (GHSA-8jr5-6gvj-rfpf).
+  AUTH_MODE: "oauth"
   # -- Comma-separated list of allowed CORS origins.
-  # In PAT mode: defaults to "*" if empty. In OAuth mode: no default (deny).
+  # In PAT-loopback mode: defaults to "*" if empty (local dev only).
+  # In OAuth mode: no default (deny browser cross-origin access).
   CORS_ALLOW_ORIGINS: ""
   # -- Max sessions before /healthz returns 503 (default 10000)
   HEALTHZ_MAX_SESSIONS: "10000"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -29,14 +29,25 @@ readinessProbe:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `PORT` | `3000` | HTTP listen port |
+| `HOST` | `127.0.0.1` | Bind address. Set to `0.0.0.0` to expose to the network — requires `AUTH_MODE=oauth`, otherwise startup refuses (GHSA-8jr5-6gvj-rfpf). |
 | `USE_SSE` | `false` | Enable legacy SSE transport |
 | `USE_STREAMABLE_HTTP` | `false` | Enable MCP Streamable HTTP transport |
-| `AUTH_MODE` | `pat` | `pat` or `oauth` |
+| `AUTH_MODE` | `pat` (app default) / `oauth` (chart default) | `pat` requires loopback bind. `oauth` accepts any bind and validates `Authorization: Bearer` per request, with sessionId bound to the originating Bearer hash. |
 | `GITLAB_API_URL` | `https://gitlab.com/api/v4` | GitLab API base URL |
 | `GITLAB_PERSONAL_ACCESS_TOKEN` | — | Required in `pat` mode |
 | `GITLAB_READ_ONLY_MODE` | `false` | Restrict to read-only tools |
-| `CORS_ALLOW_ORIGINS` | — | Comma-separated allowed origins (empty = `*` in PAT mode, deny in OAuth mode) |
+| `CORS_ALLOW_ORIGINS` | — | Comma-separated allowed origins. Empty = `*` only when `AUTH_MODE=pat` AND bind is loopback. Network-exposed binds require an explicit allowlist or get no `Allow-Origin` header. |
 | `HEALTHZ_MAX_SESSIONS` | `10000` | Session count threshold for unhealthy status |
+
+## Auth × bind matrix
+
+The HTTP transports carry no authentication of their own in `AUTH_MODE=pat`. The server's safety properties are a function of two axes — see `SECURITY.md` for the full threat model.
+
+| `AUTH_MODE` | `HOST` | Outcome |
+|---|---|---|
+| `pat` | loopback (127.0.0.0/8, ::1, localhost) | OK for local dev. Wildcard CORS permitted. |
+| `pat` | non-loopback | Refused at startup. CWE-306 / CWE-942. |
+| `oauth` | any | OK. `Authorization: Bearer` required on every request. SessionId bound to SHA-256 of the originating Bearer; reuse with a different (or missing) Bearer is rejected with 401. |
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ import {
   DeleteGroupSchema,
 } from './schemas.js';
 import { GitLabApi } from './gitlab-api.js';
-import { setupTransport } from './transport.js';
+import { setupTransport, requireSafeTransportConfig } from './transport.js';
 import {
   formatEventsResponse,
   formatCommitsResponse,
@@ -142,6 +142,13 @@ import { isValidISODate } from './utils.js';
 const GITLAB_PERSONAL_ACCESS_TOKEN = process.env.GITLAB_PERSONAL_ACCESS_TOKEN;
 const GITLAB_API_URL = process.env.GITLAB_API_URL || 'https://gitlab.com/api/v4';
 const PORT = parseInt(process.env.PORT || '3000', 10);
+/**
+ * Bind address for HTTP transports (SSE / Streamable HTTP).
+ * Default: 127.0.0.1 (loopback only). Set to 0.0.0.0 (or a specific
+ * interface) to expose to the network — but only with AUTH_MODE=oauth,
+ * otherwise the server refuses to start (CWE-306 protection).
+ */
+const HOST = process.env.HOST || '127.0.0.1';
 const USE_SSE = process.env.USE_SSE === 'true';
 const USE_STREAMABLE_HTTP = process.env.USE_STREAMABLE_HTTP === 'true';
 const GITLAB_READ_ONLY_MODE = process.env.GITLAB_READ_ONLY_MODE === 'true';
@@ -156,6 +163,19 @@ if (AUTH_MODE_RAW !== 'pat' && AUTH_MODE_RAW !== 'oauth') {
   process.exit(1);
 }
 const AUTH_MODE: 'pat' | 'oauth' = AUTH_MODE_RAW as 'pat' | 'oauth';
+
+// Startup safety gate: refuse to bind an unauthenticated HTTP server to a
+// non-loopback address. CWE-306 / CWE-942 — see SECURITY.md threat model.
+const transportSafetyError = requireSafeTransportConfig({
+  useSSE: USE_SSE,
+  useStreamableHttp: USE_STREAMABLE_HTTP,
+  host: HOST,
+  authMode: AUTH_MODE,
+});
+if (transportSafetyError) {
+  console.error(`FATAL: ${transportSafetyError}`);
+  process.exit(1);
+}
 
 // Helper function to convert Zod schema to JSON schema with proper type
 function createJsonSchema(schema: z.ZodType<any>) {
@@ -1856,6 +1876,7 @@ async function runServer() {
       }
       await setupTransport(null, {
         port: PORT,
+        host: HOST,
         useSSE: USE_SSE,
         useStreamableHttp: USE_STREAMABLE_HTTP,
         serverFactory: createMcpServer
@@ -1869,6 +1890,7 @@ async function runServer() {
       const server = createMcpServer(GITLAB_PERSONAL_ACCESS_TOKEN);
       await setupTransport(server, {
         port: PORT,
+        host: HOST,
         useSSE: USE_SSE,
         useStreamableHttp: USE_STREAMABLE_HTTP,
       });

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { setupTransport } from './transport.js';
+import { setupTransport, isLoopbackHost, requireSafeTransportConfig } from './transport.js';
 import http from 'http';
 
 /**
@@ -204,7 +204,8 @@ describe('Transport — Streamable HTTP session lifecycle', () => {
     const sessionId = initRes.headers['mcp-session-id'] as string;
     expect(sessionId).toBeDefined();
 
-    // Send initialized notification
+    // Send initialized notification — Authorization required on every
+    // existing-session request (sessionId is bound to the originating Bearer).
     const initializedPayload = JSON.stringify({
       jsonrpc: '2.0',
       method: 'notifications/initialized'
@@ -214,12 +215,13 @@ describe('Transport — Streamable HTTP session lifecycle', () => {
       {
         'Content-Type': 'application/json',
         'Accept': 'application/json, text/event-stream',
-        'MCP-Session-Id': sessionId
+        'MCP-Session-Id': sessionId,
+        Authorization: 'Bearer reuse-token'
       },
       initializedPayload
     );
 
-    // Second: list_tools on same session
+    // Second: list_tools on same session — same Bearer required.
     const listPayload = JSON.stringify({
       jsonrpc: '2.0',
       id: 2,
@@ -231,7 +233,8 @@ describe('Transport — Streamable HTTP session lifecycle', () => {
       {
         'Content-Type': 'application/json',
         'Accept': 'application/json, text/event-stream',
-        'MCP-Session-Id': sessionId
+        'MCP-Session-Id': sessionId,
+        Authorization: 'Bearer reuse-token'
       },
       listPayload
     );
@@ -269,15 +272,18 @@ describe('Transport — Streamable HTTP session lifecycle', () => {
     const sessionId = initRes.headers['mcp-session-id'] as string;
     expect(sessionId).toBeDefined();
 
-    // DELETE to close the session
+    // DELETE to close the session — Authorization required on every
+    // existing-session request.
     const delRes = await request(
       port, 'DELETE', '/mcp',
-      { 'MCP-Session-Id': sessionId }
+      { 'MCP-Session-Id': sessionId, Authorization: 'Bearer cleanup-token' }
     );
     // 200 or 204 — session terminated
     expect([200, 204]).toContain(delRes.status);
 
-    // Attempt to reuse closed session → should fail
+    // Attempt to reuse closed session → should fail.
+    // Same Bearer used; the server should reject because the session no
+    // longer exists, not because of auth.
     const reusePayload = JSON.stringify({
       jsonrpc: '2.0',
       id: 2,
@@ -289,7 +295,8 @@ describe('Transport — Streamable HTTP session lifecycle', () => {
       {
         'Content-Type': 'application/json',
         'Accept': 'application/json, text/event-stream',
-        'MCP-Session-Id': sessionId
+        'MCP-Session-Id': sessionId,
+        Authorization: 'Bearer cleanup-token'
       },
       reusePayload
     );
@@ -413,6 +420,140 @@ describe('Transport — /healthz endpoint', () => {
     expect(after).toBeGreaterThan(before);
 
     destroy();
+  });
+});
+
+describe('Transport — config safety guards (GHSA-8jr5-6gvj-rfpf)', () => {
+  it('isLoopbackHost recognises loopback variants', () => {
+    expect(isLoopbackHost('127.0.0.1')).toBe(true);
+    expect(isLoopbackHost('::1')).toBe(true);
+    expect(isLoopbackHost('localhost')).toBe(true);
+    expect(isLoopbackHost('::ffff:127.0.0.1')).toBe(true);
+  });
+
+  it('isLoopbackHost rejects network-exposed addresses', () => {
+    expect(isLoopbackHost('0.0.0.0')).toBe(false);
+    expect(isLoopbackHost('192.168.1.5')).toBe(false);
+    expect(isLoopbackHost('10.0.0.1')).toBe(false);
+    expect(isLoopbackHost('::')).toBe(false);
+  });
+
+  it('requireSafeTransportConfig allows stdio (no HTTP)', () => {
+    expect(requireSafeTransportConfig({
+      useSSE: false, useStreamableHttp: false, host: '0.0.0.0', authMode: 'pat'
+    })).toBeNull();
+  });
+
+  it('requireSafeTransportConfig allows PAT mode on loopback', () => {
+    expect(requireSafeTransportConfig({
+      useSSE: true, useStreamableHttp: false, host: '127.0.0.1', authMode: 'pat'
+    })).toBeNull();
+  });
+
+  it('requireSafeTransportConfig allows OAuth on any bind', () => {
+    expect(requireSafeTransportConfig({
+      useSSE: true, useStreamableHttp: false, host: '0.0.0.0', authMode: 'oauth'
+    })).toBeNull();
+    expect(requireSafeTransportConfig({
+      useSSE: false, useStreamableHttp: true, host: '192.168.1.5', authMode: 'oauth'
+    })).toBeNull();
+  });
+
+  it('requireSafeTransportConfig rejects PAT + non-loopback (SSE)', () => {
+    const err = requireSafeTransportConfig({
+      useSSE: true, useStreamableHttp: false, host: '0.0.0.0', authMode: 'pat'
+    });
+    expect(err).not.toBeNull();
+    expect(err).toMatch(/AUTH_MODE=oauth/);
+    expect(err).toMatch(/HOST=127\.0\.0\.1/);
+  });
+
+  it('requireSafeTransportConfig rejects PAT + non-loopback (Streamable HTTP)', () => {
+    const err = requireSafeTransportConfig({
+      useSSE: false, useStreamableHttp: true, host: '10.0.0.1', authMode: 'pat'
+    });
+    expect(err).not.toBeNull();
+  });
+
+  it('setupTransport throws when called with unsafe config (defense in depth)', async () => {
+    process.env.AUTH_MODE = 'pat';
+    await expect(setupTransport(null, {
+      port: 19999,
+      host: '0.0.0.0',
+      useSSE: true,
+      serverFactory: createTestServer,
+    })).rejects.toThrow(/non-loopback/);
+    delete process.env.AUTH_MODE;
+  });
+});
+
+describe('Transport — sessionId-Bearer binding (GHSA-8jr5-6gvj-rfpf)', () => {
+  let port: number;
+
+  beforeAll(async () => {
+    port = 19600 + Math.floor(Math.random() * 200);
+    process.env.AUTH_MODE = 'oauth';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    await setupTransport(null, {
+      port,
+      host: '127.0.0.1',
+      useSSE: true,
+      useStreamableHttp: true,
+      serverFactory: createTestServer,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('Streamable HTTP: rejects existing session reused with a different Bearer', async () => {
+    // Initialize a session with token-A
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const initRes = await request(port, 'POST', '/mcp', {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      Authorization: 'Bearer token-A',
+    }, initPayload);
+    expect(initRes.status).toBe(200);
+    const sid = initRes.headers['mcp-session-id'] as string;
+    expect(sid).toBeDefined();
+
+    // Attacker reuses sid with token-B → 401
+    const attackPayload = JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+    const attackRes = await request(port, 'POST', '/mcp', {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      Authorization: 'Bearer token-B',
+      'MCP-Session-Id': sid,
+    }, attackPayload);
+    expect(attackRes.status).toBe(401);
+    expect(attackRes.body).toMatch(/Authorization does not match/);
+  });
+
+  it('Streamable HTTP: rejects existing session reused with no Authorization header', async () => {
+    const initPayload = JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const initRes = await request(port, 'POST', '/mcp', {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      Authorization: 'Bearer leak-source',
+    }, initPayload);
+    const sid = initRes.headers['mcp-session-id'] as string;
+
+    const attackRes = await request(port, 'POST', '/mcp', {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      'MCP-Session-Id': sid,
+    }, JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
+    expect(attackRes.status).toBe(401);
   });
 });
 

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -428,14 +428,35 @@ describe('Transport — config safety guards (GHSA-8jr5-6gvj-rfpf)', () => {
     expect(isLoopbackHost('127.0.0.1')).toBe(true);
     expect(isLoopbackHost('::1')).toBe(true);
     expect(isLoopbackHost('localhost')).toBe(true);
+    expect(isLoopbackHost('LOCALHOST')).toBe(true);    // case-insensitive
+    expect(isLoopbackHost('Localhost')).toBe(true);
     expect(isLoopbackHost('::ffff:127.0.0.1')).toBe(true);
+  });
+
+  it('isLoopbackHost covers the entire 127.0.0.0/8 IPv4 range', () => {
+    // `127.x.y.z` for any x,y,z is loopback on Linux/macOS — operators
+    // sometimes pick non-127.0.0.1 addresses to dodge port conflicts.
+    expect(isLoopbackHost('127.0.0.2')).toBe(true);
+    expect(isLoopbackHost('127.5.6.7')).toBe(true);
+    expect(isLoopbackHost('127.255.255.254')).toBe(true);
+    expect(isLoopbackHost('::ffff:127.5.6.7')).toBe(true);
   });
 
   it('isLoopbackHost rejects network-exposed addresses', () => {
     expect(isLoopbackHost('0.0.0.0')).toBe(false);
     expect(isLoopbackHost('192.168.1.5')).toBe(false);
     expect(isLoopbackHost('10.0.0.1')).toBe(false);
+    expect(isLoopbackHost('128.0.0.1')).toBe(false);   // off-by-one from 127/8
     expect(isLoopbackHost('::')).toBe(false);
+    expect(isLoopbackHost('::ffff:192.168.1.5')).toBe(false);
+  });
+
+  it('isLoopbackHost rejects malformed/garbage input', () => {
+    expect(isLoopbackHost('')).toBe(false);
+    expect(isLoopbackHost('not-an-address')).toBe(false);
+    expect(isLoopbackHost('127')).toBe(false);
+    expect(isLoopbackHost('127.0.0.1.5')).toBe(false);
+    expect(isLoopbackHost('999.999.999.999')).toBe(false);
   });
 
   it('requireSafeTransportConfig allows stdio (no HTTP)', () => {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -2,20 +2,36 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { createHash, randomUUID } from "crypto";
+import { createHash, randomUUID, timingSafeEqual } from "crypto";
 import { createServer, IncomingMessage, ServerResponse } from "http";
+import { isIPv4, isIPv6 } from "net";
 import { parse } from "url";
 
 /**
  * Loopback detection — used to gate the unauthenticated PAT-mode default.
  * A non-loopback bind in PAT mode is treated as fatal misconfiguration
  * because the transport carries no auth check on /sse or /messages.
+ *
+ * Covers the full IPv4 loopback range (127.0.0.0/8 — `127.1.2.3` is just
+ * as loopback as `127.0.0.1` on Linux/macOS), the IPv6 loopback `::1`,
+ * IPv4-mapped IPv6 loopback (`::ffff:127.x.y.z`), and the case-insensitive
+ * hostname `localhost`. A naive equality check on `127.0.0.1` alone would
+ * have missed an operator binding to `127.5.6.7` for port-conflict reasons.
  */
 export function isLoopbackHost(host: string): boolean {
-  return host === '127.0.0.1'
-    || host === '::1'
-    || host === 'localhost'
-    || host === '::ffff:127.0.0.1';
+  if (host.toLowerCase() === 'localhost') return true;
+  if (isIPv4(host)) {
+    return host.startsWith('127.');
+  }
+  if (isIPv6(host)) {
+    if (host === '::1') return true;
+    // Mixed-notation IPv4-mapped IPv6: ::ffff:127.x.y.z
+    const v4Mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(host);
+    if (v4Mapped && isIPv4(v4Mapped[1])) {
+      return v4Mapped[1].startsWith('127.');
+    }
+  }
+  return false;
 }
 
 /**
@@ -177,13 +193,22 @@ export async function setupTransport(
    * In OAuth mode, every request that uses an existing sessionId must
    * present the same Bearer that opened the session. Returns true when
    * the session is unbound (PAT mode) or when the hash matches.
+   *
+   * Comparison uses crypto.timingSafeEqual to prevent a timing-based
+   * oracle attack against the stored hash (both hashes are 32-byte
+   * SHA-256 digests rendered as 64-char hex; we compare the raw bytes).
    */
   const sessionBearerMatches = (sessionId: string, req: IncomingMessage): boolean => {
     const expectedHash = sessionBearerHashes.get(sessionId);
     if (!expectedHash) return true; // PAT mode session → no hash to match
     const token = extractBearer(req);
     if (!token) return false;
-    return hashBearer(token) === expectedHash;
+    const actualHash = hashBearer(token);
+    if (actualHash.length !== expectedHash.length) return false;
+    return timingSafeEqual(
+      Buffer.from(actualHash, 'hex'),
+      Buffer.from(expectedHash, 'hex')
+    );
   };
 
   if (useSSE || useStreamableHttp) {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -17,6 +17,13 @@ import { parse } from "url";
  * IPv4-mapped IPv6 loopback (`::ffff:127.x.y.z`), and the case-insensitive
  * hostname `localhost`. A naive equality check on `127.0.0.1` alone would
  * have missed an operator binding to `127.5.6.7` for port-conflict reasons.
+ *
+ * Note on `localhost`: this is a NAME match, not a DNS/hosts-file
+ * resolution. An operator with `/etc/hosts` mapping `localhost` to a
+ * non-loopback address would pass this check by name while Node's
+ * `httpServer.listen("localhost", …)` resolves to the public IP. That
+ * scenario is operator-induced and not defended against here — for
+ * hardening configs, prefer IP literals (`127.0.0.1`) over names.
  */
 export function isLoopbackHost(host: string): boolean {
   if (host.toLowerCase() === 'localhost') return true;

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -97,8 +97,17 @@ function hashBearer(token: string): string {
 function extractBearer(req: IncomingMessage): string | null {
   const authHeader = req.headers["authorization"];
   const headerStr = Array.isArray(authHeader) ? authHeader[0] : (authHeader || "");
-  const match = headerStr.match(/^Bearer\s+(.+)$/i);
-  return match ? match[1].trim() : null;
+  // String-based parse to avoid regex backtracking on attacker-controlled
+  // headers. CodeQL js/polynomial-redos flagged the previous
+  // `/^Bearer\s+(.+)$/i` as polynomial-time on inputs like `Bearer ` plus
+  // many whitespace characters: overlapping `\s+` and greedy `(.+)` force
+  // expensive backtracking before `$` decides match/no-match (CWE-1333).
+  if (headerStr.length <= 6) return null;
+  if (headerStr.substring(0, 6).toLowerCase() !== "bearer") return null;
+  const sep = headerStr[6];
+  if (sep !== ' ' && sep !== '\t') return null;
+  const token = headerStr.substring(7).trim();
+  return token.length > 0 ? token : null;
 }
 
 /**

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -2,13 +2,53 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { createServer, IncomingMessage, ServerResponse } from "http";
 import { parse } from "url";
 
 /**
+ * Loopback detection — used to gate the unauthenticated PAT-mode default.
+ * A non-loopback bind in PAT mode is treated as fatal misconfiguration
+ * because the transport carries no auth check on /sse or /messages.
+ */
+export function isLoopbackHost(host: string): boolean {
+  return host === '127.0.0.1'
+    || host === '::1'
+    || host === 'localhost'
+    || host === '::ffff:127.0.0.1';
+}
+
+/**
+ * Validates the transport configuration before any HTTP server starts.
+ * Returns a non-null error message when the combination is unsafe.
+ *
+ * Rule: HTTP transports (SSE / Streamable HTTP) bound to a non-loopback
+ * interface must run with AUTH_MODE=oauth. A PAT-mode HTTP server on
+ * 0.0.0.0 (or any LAN-reachable address) is unauthenticated and exposes
+ * the operator's GitLab PAT to anyone who can reach the port.
+ */
+export function requireSafeTransportConfig(opts: {
+  useSSE: boolean;
+  useStreamableHttp: boolean;
+  host: string;
+  authMode: string;
+}): string | null {
+  if (!opts.useSSE && !opts.useStreamableHttp) return null;
+  if (isLoopbackHost(opts.host)) return null;
+  if (opts.authMode === 'oauth') return null;
+  return (
+    `HTTP transport on non-loopback bind (HOST=${opts.host}) requires AUTH_MODE=oauth. ` +
+    `Set HOST=127.0.0.1 for single-tenant local dev, or set AUTH_MODE=oauth and front the ` +
+    `server with a gateway that injects Authorization: Bearer.`
+  );
+}
+
+/**
  * CORS origin allowlist parsed from CORS_ALLOW_ORIGINS env var.
- * - When empty AND AUTH_MODE=pat: permissive `*` (single-tenant local dev).
+ * - When empty AND AUTH_MODE=pat AND bind is loopback: permissive `*` (local dev).
+ * - When empty AND AUTH_MODE=pat AND bind is non-loopback: no Allow-Origin header.
+ *   (The startup guard refuses this combination, but the CORS path also defends
+ *   in case the guard is bypassed in tests or future refactors.)
  * - When empty AND AUTH_MODE=oauth: no Allow-Origin header (deny browser access).
  * - When set: only listed origins receive the Allow-Origin header.
  *
@@ -24,13 +64,36 @@ function getAuthModeEnv(): string {
 }
 
 /**
+ * SHA-256 hash of a Bearer token. Used to bind a session to its
+ * originating Authorization header without storing the raw token in memory.
+ */
+function hashBearer(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function extractBearer(req: IncomingMessage): string | null {
+  const authHeader = req.headers["authorization"];
+  const headerStr = Array.isArray(authHeader) ? authHeader[0] : (authHeader || "");
+  const match = headerStr.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+/**
  * Transport configuration options
  */
 export interface TransportOptions {
   /**
-   * Port to use for SSE transport (default: 3000)
+   * Port to use for HTTP transport (default: 3000)
    */
   port?: number;
+
+  /**
+   * Bind address for HTTP transport.
+   * Default: "127.0.0.1" (loopback only). Use "0.0.0.0" or a specific
+   * interface address to expose to the network — but only with
+   * AUTH_MODE=oauth, otherwise the server refuses to start.
+   */
+  host?: string;
 
   /**
    * Whether to use SSE transport (default: false, uses stdio)
@@ -63,21 +126,64 @@ export async function setupTransport(
   server: Server | null,
   options: TransportOptions = {}
 ): Promise<void> {
-  const { port = 3000, useSSE = false, useStreamableHttp = false, serverFactory } = options;
+  const {
+    port = 3000,
+    host = '127.0.0.1',
+    useSSE = false,
+    useStreamableHttp = false,
+    serverFactory,
+  } = options;
 
-  const getSessionServer = (req: IncomingMessage): Server | null => {
+  // Defense in depth: even if a caller bypasses the index.ts startup guard,
+  // refuse to bind an unauthenticated HTTP server to a non-loopback address.
+  const configError = requireSafeTransportConfig({
+    useSSE,
+    useStreamableHttp,
+    host,
+    authMode: getAuthModeEnv(),
+  });
+  if (configError) {
+    throw new Error(`Refusing to start transport: ${configError}`);
+  }
+
+  /**
+   * sessionId → SHA-256(originating Bearer token).
+   * Populated at session creation in OAuth mode; consulted on every
+   * subsequent request that re-uses the sessionId. A leaked sessionId
+   * without the original Bearer is unusable.
+   *
+   * In PAT mode (serverFactory absent), no entries are stored, so the
+   * lookup short-circuits and behaves as before.
+   */
+  const sessionBearerHashes: Map<string, string> = new Map();
+
+  /**
+   * Build the per-connection MCP Server and capture the Bearer hash if
+   * we're in OAuth mode. Returns null when the request is unauthenticated
+   * in OAuth mode (caller should respond 401).
+   */
+  const buildSessionContext = (
+    req: IncomingMessage
+  ): { server: Server; bearerHash: string | null } | null => {
     if (!serverFactory) {
-      // PAT mode: reuse the single pre-built server.
-      return server;
+      return server ? { server, bearerHash: null } : null;
     }
+    const token = extractBearer(req);
+    if (!token) return null;
+    return { server: serverFactory(token), bearerHash: hashBearer(token) };
+  };
 
-    // OAuth mode: extract Bearer token from Authorization header.
-    const authHeader = req.headers["authorization"] || "";
-    const match = authHeader.match(/^Bearer\s+(.+)$/i);
-    if (!match) {
-      return null;
-    }
-    return serverFactory(match[1].trim());
+  /**
+   * In OAuth mode, every request that uses an existing sessionId must
+   * present the same Bearer that opened the session. Returns true when
+   * the session is unbound (PAT mode) or when the hash matches.
+   */
+  const sessionBearerMatches = (sessionId: string, req: IncomingMessage): boolean => {
+    const expectedHash = sessionBearerHashes.get(sessionId);
+    if (!expectedHash) return true; // PAT mode session → no hash to match
+    const token = extractBearer(req);
+    if (!token) return false;
+    return hashBearer(token) === expectedHash;
   };
 
   if (useSSE || useStreamableHttp) {
@@ -88,7 +194,7 @@ export async function setupTransport(
 
     // Create raw HTTP server
     const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-      // CORS handling — restrict origins in OAuth mode
+      // CORS handling — wildcard only on loopback in PAT mode; allowlist otherwise.
       const corsOrigins = getCorsAllowedOrigins();
       const authMode = getAuthModeEnv();
       const requestOrigin = req.headers.origin;
@@ -97,8 +203,9 @@ export async function setupTransport(
         res.setHeader('Access-Control-Allow-Origin', requestOrigin);
         res.setHeader('Vary', 'Origin');
         corsAllowed = true;
-      } else if (corsOrigins.length === 0 && authMode === 'pat') {
-        // Single-tenant local dev — keep permissive default
+      } else if (corsOrigins.length === 0 && authMode === 'pat' && isLoopbackHost(host)) {
+        // Loopback-only convenience for single-tenant local dev. Never
+        // emit wildcard `*` on a network-exposed bind, even in PAT mode.
         res.setHeader('Access-Control-Allow-Origin', '*');
         corsAllowed = true;
       }
@@ -137,6 +244,13 @@ export async function setupTransport(
           if (sessionId) {
             const existingTransport = transports[sessionId];
             if (existingTransport instanceof StreamableHTTPServerTransport) {
+              // OAuth-mode sessions are bound to the originating Bearer hash;
+              // a leaked sessionId without the original Bearer is rejected here.
+              if (!sessionBearerMatches(sessionId, req)) {
+                res.writeHead(401, { 'Content-Type': 'text/plain' });
+                res.end('Unauthorized: Authorization does not match the Bearer that opened this session');
+                return;
+              }
               transport = existingTransport;
             } else if (existingTransport) {
               res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -165,8 +279,8 @@ export async function setupTransport(
           }
 
           if (!transport && req.method === 'POST') {
-            const sessionServer = getSessionServer(req);
-            if (!sessionServer) {
+            const ctx = buildSessionContext(req);
+            if (!ctx) {
               res.writeHead(401, { 'Content-Type': 'text/plain' });
               res.end('Unauthorized: missing or invalid Authorization: Bearer <token> header');
               return;
@@ -178,6 +292,9 @@ export async function setupTransport(
               onsessioninitialized: (sid: string) => {
                 initializedSid = sid;
                 transports[sid] = newTransport;
+                if (ctx.bearerHash) {
+                  sessionBearerHashes.set(sid, ctx.bearerHash);
+                }
               }
             });
 
@@ -185,14 +302,18 @@ export async function setupTransport(
               const sid = newTransport.sessionId;
               if (sid && transports[sid] === newTransport) {
                 delete transports[sid];
+                sessionBearerHashes.delete(sid);
               }
             };
 
             try {
-              await sessionServer.connect(newTransport);
+              await ctx.server.connect(newTransport);
             } catch (connectError) {
               // Clean up if connect fails — onsessioninitialized may have fired
-              if (initializedSid) delete transports[initializedSid];
+              if (initializedSid) {
+                delete transports[initializedSid];
+                sessionBearerHashes.delete(initializedSid);
+              }
               try { await newTransport.close?.(); } catch { /* best-effort */ }
               throw connectError;
             }
@@ -221,9 +342,8 @@ export async function setupTransport(
             return;
           }
 
-          // Determine which server instance to use for this connection
-          const sessionServer = getSessionServer(req);
-          if (!sessionServer) {
+          const ctx = buildSessionContext(req);
+          if (!ctx) {
             res.writeHead(401, { 'Content-Type': 'text/plain' });
             res.end('Unauthorized: missing or invalid Authorization: Bearer <token> header');
             return;
@@ -236,6 +356,7 @@ export async function setupTransport(
           const cleanupSse = () => {
             if (transports[sseTransport.sessionId] === sseTransport) {
               delete transports[sseTransport.sessionId];
+              sessionBearerHashes.delete(sseTransport.sessionId);
             }
           };
 
@@ -246,8 +367,11 @@ export async function setupTransport(
           sseTransport.onclose = cleanupSse;
 
           // Connect the server to the transport — only register on success
-          await sessionServer.connect(sseTransport);
+          await ctx.server.connect(sseTransport);
           transports[sseTransport.sessionId] = sseTransport;
+          if (ctx.bearerHash) {
+            sessionBearerHashes.set(sseTransport.sessionId, ctx.bearerHash);
+          }
         }
         else if (req.method === 'POST' && pathname === '/messages') {
           if (!useSSE) {
@@ -262,6 +386,14 @@ export async function setupTransport(
           if (!(transport instanceof SSEServerTransport)) {
             res.writeHead(400);
             res.end('No transport found for sessionId');
+            return;
+          }
+
+          // OAuth-mode sessions: require the same Bearer that opened /sse.
+          // PAT-mode sessions are unbound and pass through (sessionBearerMatches returns true).
+          if (!sessionBearerMatches(sessionId, req)) {
+            res.writeHead(401, { 'Content-Type': 'text/plain' });
+            res.end('Unauthorized: Authorization does not match the Bearer that opened this session');
             return;
           }
 
@@ -281,9 +413,9 @@ export async function setupTransport(
       }
     });
 
-    // Start the server
-    httpServer.listen(port, () => {
-      console.error(`SSE server listening on port ${port}`);
+    // Start the server on the configured host (default 127.0.0.1).
+    httpServer.listen(port, host, () => {
+      console.error(`MCP HTTP transport listening on ${host}:${port}`);
     });
   } else {
     // Set up stdio transport (PAT mode only — server is always provided)


### PR DESCRIPTION
Closes [GHSA-8jr5-6gvj-rfpf](https://github.com/yoda-digital/mcp-gitlab-server/security/advisories/GHSA-8jr5-6gvj-rfpf). Reviewed and approved on the temporary private fork by reporter [@dodge1218](https://github.com/dodge1218); cherry-picked to public `main` for the v0.6.0 release.

## What was vulnerable

The SSE and Streamable HTTP transports in `AUTH_MODE=pat` (the default) carried no authentication. Combined with binding to all interfaces (also default), this exposed all 86 GitLab tools — including write tools like `push_files`, `delete_branch`, `update_project`, `create_release` — to anyone reachable on the bind. Wildcard `Access-Control-Allow-Origin: *` enabled the browser-tab cross-origin variant. The Helm chart shipped these vulnerable defaults too: `helm install` from the published OCI chart stood up the vulnerable surface inside any Kubernetes cluster.

## Defenses (three layers)

1. **Startup safety gate** (`src/index.ts` + `src/transport.ts`). `requireSafeTransportConfig` refuses to start the HTTP server when `AUTH_MODE=pat` is combined with a non-loopback bind. Enforced both at `index.ts` startup and inside `setupTransport` itself (defense in depth — a future caller can't bypass the index.ts guard).
2. **SessionId-Bearer binding** (`src/transport.ts`). OAuth-mode sessions store SHA-256 of the originating `Authorization: Bearer`. Every reuse of `MCP-Session-Id` (or SSE `sessionId`) must present the same Bearer; a leaked sessionId without the original token is rejected with 401. Comparison uses `crypto.timingSafeEqual` to prevent a timing oracle on the stored hash.
3. **Wildcard CORS only on loopback** (`src/transport.ts`). `Access-Control-Allow-Origin: *` is emitted only when bind is loopback AND `AUTH_MODE=pat` AND `CORS_ALLOW_ORIGINS` is empty. Network-exposed binds require an explicit allowlist.

Loopback detection covers the full IPv4 `127.0.0.0/8` block (an operator binding to `127.5.6.7` for port-conflict reasons is still loopback-only), `::1`, `::ffff:127.x.y.z`, and case-insensitive `localhost`. Note: `localhost` is matched by name; for hardening configs prefer the IP literal.

## Breaking changes

- **`HOST` env var defaults to `127.0.0.1`** (was implicitly `0.0.0.0`). Set `HOST=0.0.0.0` to expose to the network — but only with `AUTH_MODE=oauth`, otherwise startup refuses.
- **`chart/values.yaml`: `AUTH_MODE: \"oauth\"`** (was `\"pat\"`) and **`HOST: \"0.0.0.0\"`** (chart-required for K8s Service routing).
- **New `chart/templates/auth-validation.yaml`** fail-loud guard refuses install when `AUTH_MODE=pat` is combined with a non-loopback `HOST`.
- **Wildcard `Access-Control-Allow-Origin: *` no longer emitted on non-loopback binds** regardless of `AUTH_MODE`. Set `CORS_ALLOW_ORIGINS` explicitly.

## Migration

- **Local stdio clients (Claude Desktop, Cursor, Zed):** no change. Stdio is unaffected.
- **Local HTTP for development:** no change if you bind loopback (the new default).
- **Docker `docker run -p 3000:3000`:** in-container bind defaults to `127.0.0.1`, not reachable through port mapping. Set `HOST=0.0.0.0` *and* `AUTH_MODE=oauth` and front with a gateway.
- **Helm `helm install`:** chart defaults to `AUTH_MODE=oauth`. If you were depending on the previous `pat` default, the chart's auth-validation guard will refuse install — switch to `AUTH_MODE=oauth` and configure your Ingress/gateway to inject `Authorization: Bearer`.

Full migration notes in `CHANGELOG.md` `[0.6.0]` and `SECURITY.md` "auth × bind matrix".

## Tests

70 tests passing (was 58 + 12 new for the security work). Two existing tests updated — they encoded the vulnerable contract (sessionId alone), now require Authorization on every existing-session request.

## Verifications I ran locally

- Original advisory PoC against patched build → server refuses to start with FATAL message
- `HOST=127.5.6.7 + PAT + USE_SSE` (broader loopback range) → starts cleanly
- `HOST=128.0.0.1 + PAT + USE_SSE` (off-by-one) → refuses
- OAuth + 0.0.0.0 starts; `/sse` no Auth → 401; correct Bearer → 200
- `npm test` — 70 pass
- `helm lint chart/` clean
- `helm template t chart/` (default values) renders
- `helm-docs --chart-search-root chart/` regeneration → no drift

## Credit

[@dodge1218](https://github.com/dodge1218) — responsible disclosure with reproducible PoC, CWE mapping, design conversation on the patch shape, and rigorous review on the private fork. Co-Authored-By trailer on the squash commit.

## Post-merge

1. Release `v0.6.0` (triggers `publish-npm` via `release` event)
2. Verify npm registry has 0.6.0 with Sigstore provenance
3. Publish the GHSA advisory with `vulnerable_version_range: < 0.6.0`, `patched_versions: >= 0.6.0`
4. Request CVE through GitHub flow
5. Notify any internal Yoda Digital deployments running `USE_SSE=true` in PAT mode