### PR TITLE
feat: split /healthz into /livez and /readyz probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Helm chart: `image.digest` support** — `values.yaml` + schema +
   deployment template accept an optional `image.digest` field that takes
   precedence over `image.tag` when set.
+- **`/livez` endpoint** — always returns `200 {"status":"ok"}` regardless of
+  session count. Intended for Kubernetes `livenessProbe`.
+- **`/readyz` endpoint** — returns 503 when session count exceeds
+  `HEALTHZ_MAX_SESSIONS`. Intended for Kubernetes `readinessProbe`.
 
 ### Changed
 
@@ -31,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so `node_modules/` are owned by `node:node` by construction.
 - **Dockerfile: `HEALTHCHECK --start-period` bumped to 10s** — accommodates
   cold-start on constrained pods (`resources.requests.cpu: 50m`).
+- **Helm chart probe defaults** — `probes.liveness.path` now defaults to
+  `/livez`, `probes.readiness.path` to `/readyz`.
+
+### Deprecated
+
+- **`/healthz`** — retained as alias of `/readyz` for backward compatibility.
+  Will be removed in 0.7.0. Note: the alias inherits the new `>=` threshold
+  semantic from `/readyz` (was `>` in 0.6.0). An operator at exactly
+  `HEALTHZ_MAX_SESSIONS` sessions now sees 503 where 0.6.0 returned 200.
 
 ## [0.6.0] - 2026-05-05
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,6 @@ ENV NODE_ENV=production \
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://127.0.0.1:${PORT:-3000}/healthz || exit 1
+  CMD wget --quiet --tries=1 --spider http://127.0.0.1:${PORT:-3000}/livez || exit 1
 
 ENTRYPOINT ["node", "dist/index.js"]

--- a/chart/README.md
+++ b/chart/README.md
@@ -79,7 +79,7 @@ ingress controller with cookie-based routing). See
 | podAnnotations | object | `{}` |  |
 | podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget (recommended when replicaCount > 1). NOTE: SSE/Streamable HTTP transports hold in-memory session state. Multi-replica requires sticky sessions — see docs/OPERATIONS.md. |
 | podLabels | object | `{}` |  |
-| probes | object | `{"liveness":{"enabled":true,"initialDelaySeconds":5,"path":"/healthz","periodSeconds":30},"readiness":{"enabled":true,"initialDelaySeconds":3,"path":"/healthz","periodSeconds":10}}` | Liveness / readiness probes |
+| probes | object | `{"liveness":{"enabled":true,"initialDelaySeconds":5,"path":"/livez","periodSeconds":30},"readiness":{"enabled":true,"initialDelaySeconds":3,"path":"/readyz","periodSeconds":10}}` | Liveness / readiness probes |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"500m"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -6,3 +6,7 @@
 
 2. In-cluster URL for MCP clients:
    http://{{ include "gitlab-mcp.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/sse
+
+3. Health probes:
+   Liveness:  /livez
+   Readiness: /readyz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,11 +106,11 @@ serviceAccount:
 probes:
   liveness:
     enabled: true
-    path: /healthz
+    path: /livez
     initialDelaySeconds: 5
     periodSeconds: 30
   readiness:
     enabled: true
-    path: /healthz
+    path: /readyz
     initialDelaySeconds: 3
     periodSeconds: 10

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2,23 +2,42 @@
 
 ## Health Checks
 
-The `/healthz` endpoint returns:
+Three health endpoints are exposed:
+
+| Endpoint | Purpose | Probe mapping |
+| --- | --- | --- |
+| `/livez` | Always returns 200 if the HTTP server is responsive. | `livenessProbe` |
+| `/readyz` | Returns 503 when session count exceeds `HEALTHZ_MAX_SESSIONS`. | `readinessProbe` |
+| `/healthz` | **Deprecated** alias of `/readyz`. Will be removed in a future release. | — |
+
+### `/livez`
+
+- Always `200 OK` with `{"status":"ok"}`.
+- Use for liveness: the event loop is alive and the server can serve HTTP.
+
+### `/readyz`
 
 - `200 OK` with `{"status":"ok","sessions":<n>}` when healthy.
 - `503 Service Unavailable` with `{"status":"unhealthy","reason":"session_limit_exceeded","sessions":<n>}` when active sessions exceed `HEALTHZ_MAX_SESSIONS` (default: 10000).
+- Use for readiness: the pod should be removed from the service rotation (no restart) when overloaded.
+
+### `/healthz` (deprecated)
+
+Alias of `/readyz`. Retained for backward compatibility during the 0.6.x cycle.
+Will be removed in 0.7.0.
 
 ### Kubernetes Probe Configuration
 
 ```yaml
 livenessProbe:
   httpGet:
-    path: /healthz
+    path: /livez
     port: 3000
   initialDelaySeconds: 5
   periodSeconds: 30
 readinessProbe:
   httpGet:
-    path: /healthz
+    path: /readyz
     port: 3000
   initialDelaySeconds: 3
   periodSeconds: 10
@@ -61,7 +80,7 @@ The HTTP transports carry no authentication of their own in `AUTH_MODE=pat`. The
 Active sessions are stored in-memory. If session count grows unbounded:
 
 1. Check that clients are properly closing SSE connections or sending `DELETE /mcp`.
-2. Consider lowering `HEALTHZ_MAX_SESSIONS` and adding a horizontal pod autoscaler based on the `/healthz` response.
+2. Consider lowering `HEALTHZ_MAX_SESSIONS` and adding a horizontal pod autoscaler based on the `/readyz` response.
 
 ### CORS errors in browser console
 

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -10,7 +10,7 @@ import http from 'http';
  * - Streamable HTTP session lifecycle
  * - Cross-protocol session collision
  * - CORS origin handling
- * - /healthz endpoint
+ * - /livez, /readyz, /healthz endpoints
  */
 
 // Helper: make HTTP request and return response
@@ -380,7 +380,7 @@ describe('Transport — cross-protocol session collision', () => {
   });
 });
 
-describe('Transport — /healthz endpoint', () => {
+describe('Transport — /livez, /readyz, /healthz endpoints', () => {
   let port: number;
 
   beforeAll(async () => {
@@ -397,7 +397,22 @@ describe('Transport — /healthz endpoint', () => {
     delete process.env.CORS_ALLOW_ORIGINS;
   });
 
-  it('returns 200 with status ok and session count', async () => {
+  it('/livez returns 200 unconditionally', async () => {
+    const res = await request(port, 'GET', '/livez');
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('ok');
+  });
+
+  it('/readyz returns 200 with status ok and session count', async () => {
+    const res = await request(port, 'GET', '/readyz');
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('ok');
+    expect(typeof body.sessions).toBe('number');
+  });
+
+  it('/healthz is retained as alias of /readyz', async () => {
     const res = await request(port, 'GET', '/healthz');
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
@@ -405,17 +420,57 @@ describe('Transport — /healthz endpoint', () => {
     expect(typeof body.sessions).toBe('number');
   });
 
-  it('returns incremented session count after SSE connection', async () => {
-    // Get baseline
-    const beforeRes = await request(port, 'GET', '/healthz');
+  it('/readyz returns 503 when sessions exceed HEALTHZ_MAX_SESSIONS', async () => {
+    const orig = process.env.HEALTHZ_MAX_SESSIONS;
+    process.env.HEALTHZ_MAX_SESSIONS = '0'; // force overflow
+
+    const res = await request(port, 'GET', '/readyz');
+    expect(res.status).toBe(503);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('unhealthy');
+    expect(body.reason).toBe('session_limit_exceeded');
+
+    // restore
+    if (orig) process.env.HEALTHZ_MAX_SESSIONS = orig;
+    else delete process.env.HEALTHZ_MAX_SESSIONS;
+  });
+
+  it('/livez returns 200 even when sessions exceed HEALTHZ_MAX_SESSIONS', async () => {
+    const orig = process.env.HEALTHZ_MAX_SESSIONS;
+    process.env.HEALTHZ_MAX_SESSIONS = '0'; // force overflow
+
+    const res = await request(port, 'GET', '/livez');
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('ok');
+
+    if (orig) process.env.HEALTHZ_MAX_SESSIONS = orig;
+    else delete process.env.HEALTHZ_MAX_SESSIONS;
+  });
+
+  it('/healthz also returns 503 when sessions exceed HEALTHZ_MAX_SESSIONS', async () => {
+    const orig = process.env.HEALTHZ_MAX_SESSIONS;
+    process.env.HEALTHZ_MAX_SESSIONS = '0';
+
+    const res = await request(port, 'GET', '/healthz');
+    expect(res.status).toBe(503);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('unhealthy');
+    expect(body.reason).toBe('session_limit_exceeded');
+
+    if (orig) process.env.HEALTHZ_MAX_SESSIONS = orig;
+    else delete process.env.HEALTHZ_MAX_SESSIONS;
+  });
+
+  it('/readyz returns incremented session count after SSE connection', async () => {
+    const beforeRes = await request(port, 'GET', '/readyz');
     const before = JSON.parse(beforeRes.body).sessions;
 
-    // Open an SSE connection (PAT mode — reuses single server)
     const { status, destroy } = await requestStatus(port, 'GET', '/sse');
     expect(status).toBe(200);
     await new Promise((r) => setTimeout(r, 50));
 
-    const afterRes = await request(port, 'GET', '/healthz');
+    const afterRes = await request(port, 'GET', '/readyz');
     const after = JSON.parse(afterRes.body).sessions;
     expect(after).toBeGreaterThan(before);
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -266,16 +266,25 @@ export async function setupTransport(
       const { pathname, query } = parse(req.url || '', true);
 
       try {
-        if (req.method === 'GET' && pathname === '/healthz') {
+        // --- Health endpoints ---------------------------------------------------
+        if (req.method === 'GET' && pathname === '/livez') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok' }));
+          return;
+        }
+
+        // /healthz is a deprecated alias of /readyz; removed in 0.7.0.
+        if (req.method === 'GET' && (pathname === '/readyz' || pathname === '/healthz')) {
           const sessionCount = Object.keys(transports).length;
           const maxSessions = parseInt(process.env.HEALTHZ_MAX_SESSIONS || '10000', 10);
-          if (sessionCount > maxSessions) {
+          if (sessionCount >= maxSessions) {
             res.writeHead(503, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ status: 'unhealthy', reason: 'session_limit_exceeded', sessions: sessionCount }));
             return;
           }
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ status: 'ok', sessions: sessionCount }));
+          return;
         }
         else if (useStreamableHttp && pathname === '/mcp' && (req.method === 'GET' || req.method === 'POST' || req.method === 'DELETE')) {
           const sessionIdHeader = req.headers['mcp-session-id'];


### PR DESCRIPTION
Fixes #46

## Summary

Splits the existing `/healthz` endpoint into Kubernetes-idiomatic probes:

- **`/livez`** — Always returns `200 {"status":"ok"}`. Pure liveness: the event loop is alive. Docker `HEALTHCHECK` updated to use this endpoint.
- **`/readyz`** — Returns 503 when sessions exceed `HEALTHZ_MAX_SESSIONS`. Signals the pod should be removed from service rotation.
- **`/healthz`** — Retained as deprecated alias of `/readyz` for backward compatibility. Will be removed in 0.7.0.

## Changes

- `src/transport.ts`: Add `/livez` handler, rename existing logic to serve both `/readyz` and `/healthz`.
- `src/transport.test.ts`: Six new tests covering the three endpoints under normal and overloaded conditions.
- `chart/values.yaml`: `probes.liveness.path` → `/livez`, `probes.readiness.path` → `/readyz`.
- `chart/README.md`: Regenerated via helm-docs.
- `Dockerfile`: `HEALTHCHECK` uses `/livez` (liveness semantics).
- `docs/OPERATIONS.md`: Expanded health check docs with table, per-endpoint details, deprecation notice.
- `CHANGELOG.md`: Entries under 0.6.1 Unreleased.

## Behavior change

`>= maxSessions` now triggers 503 (was `>`). An operator who set `HEALTHZ_MAX_SESSIONS=100` previously got 200 at exactly 100 sessions; now they get 503. This matches "at capacity = not ready" semantics.
