### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to `@yoda.digital/gitlab-mcp-server` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - Unreleased
+## [Unreleased]
+
+_Nothing yet. New entries land here between releases._
+
+## [0.7.0] - 2026-05-06
 
 ### Added
 
@@ -41,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - **`/healthz`** — retained as alias of `/readyz` for backward compatibility.
-  Will be removed in 0.7.0. Note: the alias inherits the new `>=` threshold
+  Will be removed in 0.8.0. Note: the alias inherits the new `>=` threshold
   semantic from `/readyz` (was `>` in 0.6.0). An operator at exactly
   `HEALTHZ_MAX_SESSIONS` sessions now sees 503 where 0.6.0 returned 200.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -23,8 +23,8 @@ Three health endpoints are exposed:
 
 ### `/healthz` (deprecated)
 
-Alias of `/readyz`. Retained for backward compatibility during the 0.6.x cycle.
-Will be removed in 0.7.0.
+Alias of `/readyz`. Retained for backward compatibility during the 0.7.x cycle.
+Will be removed in 0.8.0.
 
 ### Kubernetes Probe Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -273,7 +273,7 @@ export async function setupTransport(
           return;
         }
 
-        // /healthz is a deprecated alias of /readyz; removed in 0.7.0.
+        // /healthz is a deprecated alias of /readyz; removed in 0.8.0.
         if (req.method === 'GET' && (pathname === '/readyz' || pathname === '/healthz')) {
           const sessionCount = Object.keys(transports).length;
           const maxSessions = parseInt(process.env.HEALTHZ_MAX_SESSIONS || '10000', 10);


### PR DESCRIPTION
Cuts 0.7.0 from main HEAD. Three small categories of edit:

- `package.json` + `package-lock.json`: 0.6.1 → 0.7.0
- `CHANGELOG.md`: dates the entries that had accumulated under `[0.6.1] - Unreleased` as `[0.7.0] - 2026-05-06`, and resets `[Unreleased]` for the next cycle
- Bumps the `/healthz` deprecation removal target from 0.7.0 to 0.8.0 in three places (CHANGELOG, `src/transport.ts:276`, `docs/OPERATIONS.md`). The alias is still alive in this release; 0.8.0 is the actual removal cycle.

Tests + helm lint clean locally. Once green and merged, `gh release create v0.7.0` per the release-driven model from #43 fires the ghcr image, Helm OCI chart, and npm publish in one ceremony.
