### PR TITLE
fix: wiki attachment multipart/form-data + per-session server factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Fixed
+
+- **Wiki attachment upload uses `multipart/form-data`** — the `upload_wiki_attachment`
+  tool was sending JSON with base64 content, causing a 400 from GitLab. Now uses
+  `FormData` + `Blob` as required by the GitLab API. Response schema corrected to
+  match actual API output (`link.url`, `link.markdown`). (#62)
+- **Per-session server factory in PAT + streamable-http mode** — a single `Server`
+  instance was shared across all streamable-http sessions, causing state corruption
+  and crashes. The `serverFactory` closure pattern (already used for OAuth) is now
+  applied to PAT mode when `USE_SSE` or `USE_STREAMABLE_HTTP` is set. (#62)
 
 ## [0.7.0] - 2026-05-06
 

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -234,16 +234,14 @@ export function formatWikiPageResponse(wikiPage: GitLabWikiPage) {
  * @returns A formatted response object for the MCP tool
  */
 export function formatWikiAttachmentResponse(attachment: GitLabWikiAttachment) {
-  // Format the attachment data
   const formattedAttachment = {
     file_name: attachment.file_name,
     file_path: attachment.file_path,
     branch: attachment.branch,
-    commit_id: attachment.commit_id,
-    url: attachment.url
+    url: attachment.link.url,
+    markdown: attachment.link.markdown
   };
 
-  // Return the formatted response
   return {
     content: [
       { type: "text", text: `Wiki Attachment: ${attachment.file_name}` },

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -1105,10 +1105,14 @@ export class GitLabApi {
       branch?: string;
     }
   ): Promise<GitLabWikiAttachment> {
-    // Convert content to base64 if it's not already
-    const content = options.content.startsWith("data:")
-      ? options.content
-      : `data:application/octet-stream;base64,${Buffer.from(options.content).toString('base64')}`;
+    const fileName = options.file_path.split('/').filter(Boolean).pop() || 'attachment';
+    const blob = new Blob([options.content], { type: 'application/octet-stream' });
+
+    const formData = new FormData();
+    formData.append('file', blob, fileName);
+    if (options.branch) {
+      formData.append('branch', options.branch);
+    }
 
     const response = await fetch(
       `${this.apiUrl}/projects/${encodeURIComponent(projectId)}/wikis/attachments`,
@@ -1116,14 +1120,8 @@ export class GitLabApi {
         method: "POST",
         headers: {
           Authorization: `Bearer ${this.token}`,
-          "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          file_name: options.file_path.split('/').pop(),
-          file_path: options.file_path,
-          content: content,
-          branch: options.branch,
-        }),
+        body: formData,
       }
     );
 
@@ -1134,10 +1132,7 @@ export class GitLabApi {
       );
     }
 
-    // Parse the response JSON
     const attachment = await response.json();
-
-    // Validate and return the response
     return GitLabWikiAttachmentSchema.parse(attachment);
   }
 
@@ -1376,10 +1371,14 @@ export class GitLabApi {
       branch?: string;
     }
   ): Promise<GitLabWikiAttachment> {
-    // Convert content to base64 if it's not already
-    const content = options.content.startsWith("data:")
-      ? options.content
-      : `data:application/octet-stream;base64,${Buffer.from(options.content).toString('base64')}`;
+    const fileName = options.file_path.split('/').filter(Boolean).pop() || 'attachment';
+    const blob = new Blob([options.content], { type: 'application/octet-stream' });
+
+    const formData = new FormData();
+    formData.append('file', blob, fileName);
+    if (options.branch) {
+      formData.append('branch', options.branch);
+    }
 
     const response = await fetch(
       `${this.apiUrl}/groups/${encodeURIComponent(groupId)}/wikis/attachments`,
@@ -1387,14 +1386,8 @@ export class GitLabApi {
         method: "POST",
         headers: {
           Authorization: `Bearer ${this.token}`,
-          "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          file_name: options.file_path.split('/').pop(),
-          file_path: options.file_path,
-          content: content,
-          branch: options.branch,
-        }),
+        body: formData,
       }
     );
 
@@ -1405,10 +1398,7 @@ export class GitLabApi {
       );
     }
 
-    // Parse the response JSON
     const attachment = await response.json();
-
-    // Validate and return the response
     return GitLabWikiAttachmentSchema.parse(attachment);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1893,6 +1893,9 @@ async function runServer() {
         host: HOST,
         useSSE: USE_SSE,
         useStreamableHttp: USE_STREAMABLE_HTTP,
+        serverFactory: (USE_SSE || USE_STREAMABLE_HTTP)
+          ? () => createMcpServer(GITLAB_PERSONAL_ACCESS_TOKEN)
+          : undefined,
       });
     }
     const enabledTransports = [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -344,8 +344,10 @@ export const GitLabWikiAttachmentSchema = z.object({
   file_name: z.string(),
   file_path: z.string(),
   branch: z.string(),
-  commit_id: z.string(),
-  url: z.string().optional()
+  link: z.object({
+    url: z.string(),
+    markdown: z.string()
+  })
 });
 
 export type GitLabWikiAttachment = z.infer<typeof GitLabWikiAttachmentSchema>;

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -200,6 +200,12 @@ export async function setupTransport(
     if (!serverFactory) {
       return server ? { server, bearerHash: null } : null;
     }
+    // If a static server is also provided, this is PAT mode with per-session
+    // factory (needed for streamable-http multi-session). No Bearer required.
+    if (server) {
+      return { server: serverFactory(''), bearerHash: null };
+    }
+    // OAuth mode: Bearer is mandatory
     const token = extractBearer(req);
     if (!token) return null;
     return { server: serverFactory(token), bearerHash: hashBearer(token) };


### PR DESCRIPTION
## Summary

Two bug fixes discovered through comprehensive E2E testing against a real GitLab CE instance.

---

### 1. Wiki attachment upload uses wrong Content-Type

**Problem**: `uploadProjectWikiAttachment` and `uploadGroupWikiAttachment` send a JSON body with a base64-encoded data URI. The GitLab API requires `multipart/form-data` with a `file` field ([docs](https://docs.gitlab.com/api/wikis/#upload-an-attachment-to-the-wiki)). This causes **400 Bad Request on every call**.

**Fix**:
- Use `FormData` + `Blob` instead of JSON body
- Remove explicit `Content-Type: application/json` (let the runtime set the multipart boundary)
- Fix `GitLabWikiAttachmentSchema` to match the actual API response: the response contains `{ file_name, file_path, branch, link: { url, markdown } }` — not the non-existent `commit_id` / top-level `url` fields
- Fix `formatWikiAttachmentResponse` accordingly

**Files**: `src/gitlab-api.ts`, `src/schemas.ts`, `src/formatters.ts`

---

### 2. Per-session server factory for streamable-http + PAT mode

**Problem**: Streamable HTTP creates a new transport per session. With a single shared `Server` instance, the second concurrent session triggers `"Already connected to a transport"`, crashing the server.

**Fix**: When streamable-http is enabled in PAT mode, provide a `serverFactory` closure that creates a new `Server` per session. `buildSessionContext` detects PAT mode (server ≠ null + factory present) and skips Bearer token extraction.

**Files**: `src/index.ts`, `src/transport.ts`

---

### Testing

Both issues were discovered and validated through full E2E tests (real GitLab CE, real MCP protocol calls). A companion PR will add the complete E2E test suite.
