### PR TITLE
fix(schemas): make user/member avatar_url nullable for GitLab EE (closes #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Fixed
+
+- **`avatar_url` schema validation against GitLab EE (#74)** — `GitLabUserSchema`
+  and `GitLabMemberSchema` now accept `null` for `avatar_url`. The GitLab API
+  docs declare it as `string`, but GitLab EE returns `null` for users without a
+  custom avatar. Without this fix, `GetMergeRequestChanges`,
+  `list_merge_request_notes`, and `list_merge_request_discussions` throw
+  `Invalid arguments: author.avatar_url: Expected string, received null` on
+  every call. Added regression tests covering both `null` and string values.
 
 ## [0.7.0] - 2026-05-06
 

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -51,6 +51,9 @@ import {
   CreateGroupSchema,
   UpdateGroupSchema,
   DeleteGroupSchema,
+  // Response Schemas
+  GitLabUserSchema,
+  GitLabMemberSchema,
 } from './schemas.js';
 
 describe('CI/CD Schemas', () => {
@@ -344,6 +347,60 @@ describe('User Schemas', () => {
       });
       expect(valid.search).toBe('john');
       expect(valid.active).toBe(true);
+    });
+  });
+});
+
+// Regression: GitLab EE 17.5.5 returns null for avatar_url on author/assignees/notes
+// where the docs declare it as `string`. See issue #74.
+describe('Response schemas — GitLab EE nullability', () => {
+  describe('GitLabUserSchema', () => {
+    it('accepts a user with null avatar_url (EE behavior)', () => {
+      const parsed = GitLabUserSchema.parse({
+        id: 42,
+        name: 'Ghost User',
+        username: 'ghost',
+        avatar_url: null,
+        web_url: 'https://gitlab.example.com/ghost'
+      });
+      expect(parsed.avatar_url).toBeNull();
+    });
+
+    it('still accepts a user with string avatar_url', () => {
+      const parsed = GitLabUserSchema.parse({
+        id: 1,
+        name: 'Admin',
+        username: 'root',
+        avatar_url: 'https://gitlab.example.com/uploads/-/system/user/avatar/1/avatar.png',
+        web_url: 'https://gitlab.example.com/root'
+      });
+      expect(parsed.avatar_url).toBe('https://gitlab.example.com/uploads/-/system/user/avatar/1/avatar.png');
+    });
+
+    it('still accepts a user with avatar_url omitted', () => {
+      const parsed = GitLabUserSchema.parse({
+        id: 7,
+        name: 'Lite User',
+        username: 'lite',
+        web_url: 'https://gitlab.example.com/lite'
+      });
+      expect(parsed.avatar_url).toBeUndefined();
+    });
+  });
+
+  describe('GitLabMemberSchema', () => {
+    it('accepts a member with null avatar_url', () => {
+      const parsed = GitLabMemberSchema.parse({
+        id: 9,
+        username: 'member',
+        name: 'Project Member',
+        state: 'active',
+        avatar_url: null,
+        web_url: 'https://gitlab.example.com/member',
+        access_level: 30,
+        expires_at: null,
+      });
+      expect(parsed.avatar_url).toBeNull();
     });
   });
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -51,11 +51,14 @@ export const GitLabDiscussionsResponseSchema = z.object({
 export type GitLabDiscussionsResponse = z.infer<typeof GitLabDiscussionsResponseSchema>;
 
 // GitLab User
+// Note: avatar_url is documented as `string` in the GitLab API, but GitLab EE
+// can return `null` (e.g. for users without a custom avatar). Keep it nullable
+// to avoid breaking on real EE traffic — see issue #74.
 export const GitLabUserSchema = z.object({
   id: z.number(),
   name: z.string(),
   username: z.string(),
-  avatar_url: z.string().optional(),
+  avatar_url: z.string().nullable().optional(),
   web_url: z.string().optional()
 });
 
@@ -615,7 +618,7 @@ export const GitLabMemberSchema = z.object({
   username: z.string(),
   name: z.string(),
   state: z.string(),
-  avatar_url: z.string().optional(),
+  avatar_url: z.string().nullable().optional(),
   web_url: z.string(),
   access_level: z.number(),
   access_level_description: z.string().optional(),


### PR DESCRIPTION
## Problem

`dMikhalchev` reported in #74 that three tools throw on GitLab Enterprise Edition 17.5.5:

```
MCP error -32603: Invalid arguments:
  author.avatar_url: Expected string, received null,
  assignees.0.avatar_url: Expected string, received null

MCP error -32603: Invalid arguments:
  notes.0.author.avatar_url: Expected string, received null
```

Affected tools:
- `GetMergeRequestChanges`
- `list_merge_request_notes`
- `list_merge_request_discussions`

## Root cause

The GitLab REST API docs declare `avatar_url` as `string`, but in practice EE returns `null` for users without a custom avatar (and likely for deactivated/ghost users too). gitlab.com synthesizes a Gravatar URL so the issue is invisible on the SaaS path — only EE exposes the raw null.

## Fix

Two schemas in `src/schemas.ts` had `avatar_url: z.string().optional()`:
- `GitLabUserSchema` (line 58) — used by `author`, `assignees[]`, and `notes[].author` shapes throughout the codebase
- `GitLabMemberSchema` (line 618) — used by member-list tools

Both are now `.nullable().optional()`. A doc comment was added to `GitLabUserSchema` explaining the EE-vs-SaaS divergence so future contributors don't ""fix"" it back.

## Tests

Added a new `describe` block in `src/schemas.test.ts` exercising:
- `GitLabUserSchema` with `avatar_url: null` (the EE case)
- `GitLabUserSchema` with `avatar_url: '...'` (the SaaS case)
- `GitLabUserSchema` with `avatar_url` omitted (defensive)
- `GitLabMemberSchema` with `avatar_url: null`

Test count: 75 → 79, all passing locally (`npm test`).

## CHANGELOG

Added an entry under `[Unreleased]` so the next release picks it up.

Closes #74