### PR TITLE
chore(deps): override ip-address to 10.1.1 (GHSA-v2v4-37r5-5v8g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Override `ip-address` to 10.1.1 (GHSA-v2v4-37r5-5v8g, moderate)** — closes
+  the XSS vulnerability in `Address6` HTML-emitting methods. The package is
+  pulled transitively via `@modelcontextprotocol/sdk → express-rate-limit → ip-address`
+  and was pinned at the vulnerable 10.1.0 in the lockfile. Added an `overrides`
+  entry in `package.json` to force the patched version regardless of upstream
+  resolution.
+
 ### Fixed
 
 - **`avatar_url` schema validation against GitLab EE (#74)** — `GitLabUserSchema`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1631,9 +1631,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "homepage": "https://opensource.yoda.digital/en/projects/mcp-gitlab-server/",
   "overrides": {
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "ip-address": "10.1.1"
   }
 }


### PR DESCRIPTION
## Problem

\`ip-address@10.1.0\` has a moderate XSS vulnerability in \`Address6\` HTML-emitting methods ([GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g)). It's the **last remaining open Dependabot alert** on the repo — the previous five were closed by #65 (\`fast-uri\`) and #66 (\`hono\`).

## Why no auto Dependabot PR

\`ip-address\` is pulled transitively, not declared directly:

\`\`\`
@yoda.digital/gitlab-mcp-server@0.7.0
└─┬ @modelcontextprotocol/sdk@1.29.0
  └─┬ express-rate-limit@8.4.1
    └── ip-address@10.1.0
\`\`\`

\`express-rate-limit@8.4.1\` does not yet pin \`ip-address >= 10.1.1\`, so Dependabot cannot auto-fix without a parent bump.

## Fix

Add an \`overrides\` entry in \`package.json\` to force the patched version:

\`\`\`json
\"overrides\": {
  \"vite\": \"^8.0.0\",
  \"ip-address\": \"10.1.1\"
}
\`\`\`

## Verification

\`\`\`bash
npm ls ip-address
# @yoda.digital/gitlab-mcp-server@0.7.0
# └─┬ @modelcontextprotocol/sdk@1.29.0
#   └─┬ express-rate-limit@8.4.1
#     └── ip-address@10.1.1 overridden

npm audit
# found 0 vulnerabilities

npm run build && npm test
# build clean, 75 tests passed
\`\`\`

## CHANGELOG

Added an entry under \`[Unreleased] > Security\`.