### PR TITLE
chore(release): 0.7.1 — security + EE schema fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet. New entries land here between releases._
+
+## [0.7.1] - 2026-05-18
+
+Security + schema-correctness release. Closes all six open Dependabot alerts and a production-breaker for GitLab EE users.
+
 ### Security
 
-- **Override `ip-address` to 10.1.1 (GHSA-v2v4-37r5-5v8g, moderate)** — closes
-  the XSS vulnerability in `Address6` HTML-emitting methods. The package is
-  pulled transitively via `@modelcontextprotocol/sdk → express-rate-limit → ip-address`
-  and was pinned at the vulnerable 10.1.0 in the lockfile. Added an `overrides`
-  entry in `package.json` to force the patched version regardless of upstream
-  resolution.
+- **`fast-uri` 3.1.0 → 3.1.2 (#65)** — closes [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (path traversal, HIGH) and [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (host confusion, HIGH).
+- **`hono` 4.12.16 → 4.12.18 (#66)** — closes [GHSA-qp7p-654g-cw7p](https://github.com/advisories/GHSA-qp7p-654g-cw7p) (CSS injection JSX SSR), [GHSA-p77w-8qqv-26rm](https://github.com/advisories/GHSA-p77w-8qqv-26rm) (Cache Vary leak), and [GHSA-hm8q-7f3q-5f36](https://github.com/advisories/GHSA-hm8q-7f3q-5f36) (JWT NumericDate).
+- **Override `ip-address` to 10.1.1 (#78)** — closes [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) (XSS in `Address6`, moderate). Pulled transitively via `@modelcontextprotocol/sdk → express-rate-limit → ip-address` and not auto-fixable by Dependabot until `express-rate-limit` re-pins it.
 
 ### Fixed
 
-- **`avatar_url` schema validation against GitLab EE (#74)** — `GitLabUserSchema`
-  and `GitLabMemberSchema` now accept `null` for `avatar_url`. The GitLab API
-  docs declare it as `string`, but GitLab EE returns `null` for users without a
-  custom avatar. Without this fix, `GetMergeRequestChanges`,
-  `list_merge_request_notes`, and `list_merge_request_discussions` throw
-  `Invalid arguments: author.avatar_url: Expected string, received null` on
-  every call. Added regression tests covering both `null` and string values.
+- **`avatar_url` schema validation against GitLab EE (#74, #77)** — `GitLabUserSchema` and `GitLabMemberSchema` now accept `null` for `avatar_url`. The GitLab API docs declare it as `string`, but GitLab EE 17.5.5 returns `null` for users without a custom avatar (gitlab.com synthesizes a Gravatar URL so the issue is SaaS-invisible). Without this fix, `GetMergeRequestChanges`, `list_merge_request_notes`, and `list_merge_request_discussions` throw `Invalid arguments: author.avatar_url: Expected string, received null` on every call against EE. Added regression tests covering null, string, and undefined `avatar_url` paths.
+- **Revert accidental `mempalace.yaml` from main (#76)** — personal MemPalace plugin state landed at `165ea06`; the release-driven publish model (#43) prevented npm pollution. The revert also adds `mempalace.yaml`, `.mempalace/`, and `entities.json` to `.gitignore` to prevent recurrence.
+
+### Changed
+
+- **`hadolint/hadolint-action` 3.1.0 → 3.3.0 (#68)** — CI minor bump.
+- **`@types/node` 20.19.39 → 20.19.41, `vitest` 4.1.5 → 4.1.6 (#75)** — dev deps minor-patch group.
 
 ## [0.7.0] - 2026-05-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Security + schema-correctness release.

## Closes all 6 Dependabot alerts

| Package | Severity | Advisory | PR |
|---|---|---|---|
| fast-uri | HIGH | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (path traversal) | #65 |
| fast-uri | HIGH | [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (host confusion) | #65 |
| hono | medium | [GHSA-qp7p-654g-cw7p](https://github.com/advisories/GHSA-qp7p-654g-cw7p) (CSS injection JSX SSR) | #66 |
| hono | medium | [GHSA-p77w-8qqv-26rm](https://github.com/advisories/GHSA-p77w-8qqv-26rm) (Cache Vary leak) | #66 |
| hono | low | [GHSA-hm8q-7f3q-5f36](https://github.com/advisories/GHSA-hm8q-7f3q-5f36) (JWT NumericDate) | #66 |
| ip-address | medium | [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) (XSS) | #78 |

## Closes production-breaker on GitLab EE

- **#74**: GitLab EE 17.5.5 returns `null` for `avatar_url`. Three tools throw on every call. Fixed in #77 by making `GitLabUserSchema` and `GitLabMemberSchema` nullable on that field. New regression tests cover null/string/undefined paths.

## Repo hygiene

- **#76**: Revert accidental \`mempalace.yaml\` commit + harden \`.gitignore\`.
- **#68**: hadolint CI action patch bump.
- **#75**: dev deps minor-patch group (@types/node + vitest).

## Release ceremony

Merging this PR is the version-bump + CHANGELOG commit. The npm publish triggers on the **GitHub release** that follows, per the release-driven publish model (#43). Sequence:

1. Merge this PR.
2. Create release \`v0.7.1\` on GitHub from the merge commit, with CHANGELOG section as body.
3. \`publish.yml\` runs on \`release: published\` → publishes to npm via OIDC Trusted Publishing.

## Verification

- \`npm run build\`: clean
- \`npm test\`: 79 passed (4 new schema tests + 75 existing)
- \`npm audit\`: 0 vulnerabilities
- Test count delta: 75 → 79 (no test theater; the 4 new tests cover the new code paths added for #74)