### PR TITLE
fix(wiki+transport): rebase of #62 with maintainer corrections + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Fixed
+
+- **Wiki attachment upload uses `multipart/form-data`** — the `upload_wiki_attachment`
+  tool was sending JSON with base64 content, causing a 400 from GitLab. Now uses
+  `FormData` + `Blob` as required by the GitLab API. Response schema corrected to
+  match actual API output (`link.url`, `link.markdown`). (#62)
+- **Per-session server factory in PAT + streamable-http mode** — a single `Server`
+  instance was shared across all streamable-http sessions, causing state corruption
+  and crashes. The `serverFactory` closure pattern (already used for OAuth) is now
+  applied to PAT mode when `USE_SSE` or `USE_STREAMABLE_HTTP` is set. (#62)
 
 ## [0.7.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet. New entries land here between releases._
+
+## [0.7.2] - 2026-05-18
+
+Wiki upload + PAT-mode concurrency fixes. Carries the two contributions from #62 (Olivier Gintrand) with maintainer-side corrections: an explicit `content_encoding` parameter for binary uploads, a schema fallback for older self-hosted GitLab, and regression tests for both fixes.
+
 ### Fixed
 
-- **Wiki attachment upload uses `multipart/form-data`** — the `upload_wiki_attachment`
-  tool was sending JSON with base64 content, causing a 400 from GitLab. Now uses
-  `FormData` + `Blob` as required by the GitLab API. Response schema corrected to
-  match actual API output (`link.url`, `link.markdown`). (#62)
-- **Per-session server factory in PAT + streamable-http mode** — a single `Server`
-  instance was shared across all streamable-http sessions, causing state corruption
-  and crashes. The `serverFactory` closure pattern (already used for OAuth) is now
-  applied to PAT mode when `USE_SSE` or `USE_STREAMABLE_HTTP` is set. (#62)
+- **Wiki attachment upload uses `multipart/form-data`** — the `upload_project_wiki_attachment`
+  and `upload_group_wiki_attachment` tools previously sent JSON with base64 content,
+  causing a 400 from GitLab on every call. Now uses `FormData` + `Blob` as required
+  by the [GitLab wiki attachments API](https://docs.gitlab.com/api/wikis/#upload-an-attachment-to-the-wiki).
+  Originally from #62 by @ecthelion77.
+- **Per-session server factory in PAT + streamable-http mode** — a single shared
+  `Server` instance across streamable-http sessions raised
+  `"Already connected to a transport"` on the second concurrent client and crashed
+  the process. The `serverFactory` closure pattern (already used for OAuth) is now
+  applied to PAT mode when `USE_SSE` or `USE_STREAMABLE_HTTP` is set, so each
+  session gets its own `Server`. Originally from #62 by @ecthelion77.
+
+### Added
+
+- **`content_encoding` parameter on wiki upload tools** — `'utf8'` (default,
+  current behaviour: content treated as raw text/bytes) or `'base64'` (decoded
+  before upload, required for binary files since MCP parameters are JSON strings).
+  No automatic detection: false positives on alphanumeric text would silently
+  corrupt uploads.
+
+### Changed
+
+- **`GitLabWikiAttachment` MCP response shape** — the formatted tool output
+  now exposes `{url, markdown}` (sourced from the modern API's `link` object).
+  The previous `commit_id` field is no longer surfaced. Downstream LLM consumers
+  parsing this output should update accordingly.
+
+### Compatibility
+
+- **Older self-hosted GitLab versions** that return the legacy flat
+  `{commit_id, url}` shape are still parsed correctly. `GitLabWikiAttachmentSchema`
+  accepts either the modern `link.{url, markdown}` envelope or the flat legacy
+  fields; the formatter normalises into a single output shape with a synthesised
+  markdown snippet on legacy paths.
 
 ## [0.7.1] - 2026-05-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -234,16 +234,14 @@ export function formatWikiPageResponse(wikiPage: GitLabWikiPage) {
  * @returns A formatted response object for the MCP tool
  */
 export function formatWikiAttachmentResponse(attachment: GitLabWikiAttachment) {
-  // Format the attachment data
   const formattedAttachment = {
     file_name: attachment.file_name,
     file_path: attachment.file_path,
     branch: attachment.branch,
-    commit_id: attachment.commit_id,
-    url: attachment.url
+    url: attachment.link.url,
+    markdown: attachment.link.markdown
   };
 
-  // Return the formatted response
   return {
     content: [
       { type: "text", text: `Wiki Attachment: ${attachment.file_name}` },

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -234,12 +234,17 @@ export function formatWikiPageResponse(wikiPage: GitLabWikiPage) {
  * @returns A formatted response object for the MCP tool
  */
 export function formatWikiAttachmentResponse(attachment: GitLabWikiAttachment) {
+  // Recent GitLab returns link.{url,markdown}; older versions return a flat url.
+  // Always emit a non-empty url and a usable markdown snippet so consumers
+  // never see undefined fields.
+  const url = attachment.link?.url ?? attachment.url ?? '';
+  const markdown = attachment.link?.markdown ?? `![${attachment.file_name}](${url})`;
   const formattedAttachment = {
     file_name: attachment.file_name,
     file_path: attachment.file_path,
     branch: attachment.branch,
-    url: attachment.link.url,
-    markdown: attachment.link.markdown
+    url,
+    markdown
   };
 
   return {

--- a/src/gitlab-api.test.ts
+++ b/src/gitlab-api.test.ts
@@ -74,3 +74,146 @@ describe('GitLabApi.listIssues', () => {
     expect(result.count).toBe(1);
   });
 });
+
+describe('GitLabApi.uploadProjectWikiAttachment (#62)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  function mockWikiAttachmentResponse(payload: unknown) {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      statusText: 'OK',
+      headers: { get: () => null },
+      json: async () => payload,
+    } as unknown as Awaited<ReturnType<typeof fetch>>);
+  }
+
+  it('sends a multipart/form-data body with the file blob, no Content-Type override', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    mockWikiAttachmentResponse({
+      file_name: 'note.md',
+      file_path: 'uploads/note.md',
+      branch: 'main',
+      link: { url: '/uploads/abc/note.md', markdown: '[note.md](/uploads/abc/note.md)' },
+    });
+
+    await api.uploadProjectWikiAttachment('my-proj', {
+      file_path: 'docs/note.md',
+      content: 'hello world',
+      branch: 'main',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    const body = (init as RequestInit).body;
+    expect(body).toBeInstanceOf(FormData);
+    // Headers should not include Content-Type — runtime sets the multipart boundary.
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['Content-Type']).toBeUndefined();
+    expect(headers['content-type']).toBeUndefined();
+
+    const fd = body as FormData;
+    const file = fd.get('file');
+    expect(file).toBeInstanceOf(Blob);
+    expect((file as Blob).type).toBe('application/octet-stream');
+    expect(fd.get('branch')).toBe('main');
+  });
+
+  it('omits branch from form when not provided', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    mockWikiAttachmentResponse({
+      file_name: 'note.md', file_path: 'uploads/note.md', branch: 'main',
+      link: { url: '/uploads/abc/note.md', markdown: '![note.md](/uploads/abc/note.md)' },
+    });
+
+    await api.uploadProjectWikiAttachment('my-proj', {
+      file_path: 'docs/note.md',
+      content: 'hello',
+    });
+
+    const fd = (fetchMock.mock.calls[0][1] as RequestInit).body as FormData;
+    expect(fd.has('branch')).toBe(false);
+  });
+
+  it('base64-decodes content when content_encoding is base64', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    mockWikiAttachmentResponse({
+      file_name: 'image.png', file_path: 'uploads/image.png', branch: 'main',
+      link: { url: '/uploads/img.png', markdown: '![image.png](/uploads/img.png)' },
+    });
+
+    // 4-byte PNG file signature: 89 50 4E 47
+    const pngSignature = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const base64 = pngSignature.toString('base64'); // 'iVBORw=='
+
+    await api.uploadProjectWikiAttachment('my-proj', {
+      file_path: 'image.png',
+      content: base64,
+      content_encoding: 'base64',
+    });
+
+    const fd = (fetchMock.mock.calls[0][1] as RequestInit).body as FormData;
+    const blob = fd.get('file') as Blob;
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    expect(bytes[0]).toBe(0x89);
+    expect(bytes[1]).toBe(0x50);
+    expect(bytes[2]).toBe(0x4e);
+    expect(bytes[3]).toBe(0x47);
+  });
+
+  it('treats content as raw text when content_encoding is omitted (default utf8)', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    mockWikiAttachmentResponse({
+      file_name: 'a.txt', file_path: 'a.txt', branch: 'main',
+      link: { url: '/uploads/a.txt', markdown: '[a.txt](/uploads/a.txt)' },
+    });
+
+    const text = 'iVBORw=='; // looks like base64 but caller didn't opt in
+    await api.uploadProjectWikiAttachment('my-proj', {
+      file_path: 'a.txt',
+      content: text,
+    });
+
+    const fd = (fetchMock.mock.calls[0][1] as RequestInit).body as FormData;
+    const blob = fd.get('file') as Blob;
+    expect(await blob.text()).toBe('iVBORw==');
+  });
+
+  it('parses the modern GitLab response shape (link.url, link.markdown)', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    mockWikiAttachmentResponse({
+      file_name: 'doc.md',
+      file_path: 'uploads/doc.md',
+      branch: 'main',
+      link: { url: '/uploads/xyz/doc.md', markdown: '[doc.md](/uploads/xyz/doc.md)' },
+    });
+
+    const result = await api.uploadProjectWikiAttachment('my-proj', {
+      file_path: 'doc.md', content: 'x',
+    });
+
+    expect(result.link?.url).toBe('/uploads/xyz/doc.md');
+    expect(result.link?.markdown).toBe('[doc.md](/uploads/xyz/doc.md)');
+  });
+
+  it('parses the legacy GitLab response shape (flat url, commit_id)', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    // Older self-hosted GitLab returned the flat shape.
+    mockWikiAttachmentResponse({
+      file_name: 'old.md',
+      file_path: 'uploads/old.md',
+      branch: 'main',
+      url: '/uploads/legacy/old.md',
+      commit_id: 'abc123',
+    });
+
+    const result = await api.uploadProjectWikiAttachment('my-proj', {
+      file_path: 'old.md', content: 'x',
+    });
+
+    expect(result.link).toBeUndefined();
+    expect(result.url).toBe('/uploads/legacy/old.md');
+    expect(result.commit_id).toBe('abc123');
+  });
+});

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -1105,10 +1105,14 @@ export class GitLabApi {
       branch?: string;
     }
   ): Promise<GitLabWikiAttachment> {
-    // Convert content to base64 if it's not already
-    const content = options.content.startsWith("data:")
-      ? options.content
-      : `data:application/octet-stream;base64,${Buffer.from(options.content).toString('base64')}`;
+    const fileName = options.file_path.split('/').filter(Boolean).pop() || 'attachment';
+    const blob = new Blob([options.content], { type: 'application/octet-stream' });
+
+    const formData = new FormData();
+    formData.append('file', blob, fileName);
+    if (options.branch) {
+      formData.append('branch', options.branch);
+    }
 
     const response = await fetch(
       `${this.apiUrl}/projects/${encodeURIComponent(projectId)}/wikis/attachments`,
@@ -1116,14 +1120,8 @@ export class GitLabApi {
         method: "POST",
         headers: {
           Authorization: `Bearer ${this.token}`,
-          "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          file_name: options.file_path.split('/').pop(),
-          file_path: options.file_path,
-          content: content,
-          branch: options.branch,
-        }),
+        body: formData,
       }
     );
 
@@ -1134,10 +1132,7 @@ export class GitLabApi {
       );
     }
 
-    // Parse the response JSON
     const attachment = await response.json();
-
-    // Validate and return the response
     return GitLabWikiAttachmentSchema.parse(attachment);
   }
 
@@ -1376,10 +1371,14 @@ export class GitLabApi {
       branch?: string;
     }
   ): Promise<GitLabWikiAttachment> {
-    // Convert content to base64 if it's not already
-    const content = options.content.startsWith("data:")
-      ? options.content
-      : `data:application/octet-stream;base64,${Buffer.from(options.content).toString('base64')}`;
+    const fileName = options.file_path.split('/').filter(Boolean).pop() || 'attachment';
+    const blob = new Blob([options.content], { type: 'application/octet-stream' });
+
+    const formData = new FormData();
+    formData.append('file', blob, fileName);
+    if (options.branch) {
+      formData.append('branch', options.branch);
+    }
 
     const response = await fetch(
       `${this.apiUrl}/groups/${encodeURIComponent(groupId)}/wikis/attachments`,
@@ -1387,14 +1386,8 @@ export class GitLabApi {
         method: "POST",
         headers: {
           Authorization: `Bearer ${this.token}`,
-          "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          file_name: options.file_path.split('/').pop(),
-          file_path: options.file_path,
-          content: content,
-          branch: options.branch,
-        }),
+        body: formData,
       }
     );
 
@@ -1405,10 +1398,7 @@ export class GitLabApi {
       );
     }
 
-    // Parse the response JSON
     const attachment = await response.json();
-
-    // Validate and return the response
     return GitLabWikiAttachmentSchema.parse(attachment);
   }
 

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -1102,11 +1102,15 @@ export class GitLabApi {
     options: {
       file_path: string;
       content: string;
+      content_encoding?: 'utf8' | 'base64';
       branch?: string;
     }
   ): Promise<GitLabWikiAttachment> {
     const fileName = options.file_path.split('/').filter(Boolean).pop() || 'attachment';
-    const blob = new Blob([options.content], { type: 'application/octet-stream' });
+    const bytes = options.content_encoding === 'base64'
+      ? Buffer.from(options.content, 'base64')
+      : options.content;
+    const blob = new Blob([bytes], { type: 'application/octet-stream' });
 
     const formData = new FormData();
     formData.append('file', blob, fileName);
@@ -1368,11 +1372,15 @@ export class GitLabApi {
     options: {
       file_path: string;
       content: string;
+      content_encoding?: 'utf8' | 'base64';
       branch?: string;
     }
   ): Promise<GitLabWikiAttachment> {
     const fileName = options.file_path.split('/').filter(Boolean).pop() || 'attachment';
-    const blob = new Blob([options.content], { type: 'application/octet-stream' });
+    const bytes = options.content_encoding === 'base64'
+      ? Buffer.from(options.content, 'base64')
+      : options.content;
+    const blob = new Blob([bytes], { type: 'application/octet-stream' });
 
     const formData = new FormData();
     formData.append('file', blob, fileName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1893,6 +1893,9 @@ async function runServer() {
         host: HOST,
         useSSE: USE_SSE,
         useStreamableHttp: USE_STREAMABLE_HTTP,
+        serverFactory: (USE_SSE || USE_STREAMABLE_HTTP)
+          ? () => createMcpServer(GITLAB_PERSONAL_ACCESS_TOKEN)
+          : undefined,
       });
     }
     const enabledTransports = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1070,6 +1070,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         const attachment = await gitlabApi.uploadProjectWikiAttachment(args.project_id, {
           file_path: args.file_path,
           content: args.content,
+          content_encoding: args.content_encoding,
           branch: args.branch
         });
         return formatWikiAttachmentResponse(attachment);
@@ -1124,6 +1125,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         const attachment = await gitlabApi.uploadGroupWikiAttachment(args.group_id, {
           file_path: args.file_path,
           content: args.content,
+          content_encoding: args.content_encoding,
           branch: args.branch
         });
         return formatWikiAttachmentResponse(attachment);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -343,6 +343,9 @@ export const GitLabWikiPagesResponseSchema = z.object({
 export type GitLabWikiPagesResponse = z.infer<typeof GitLabWikiPagesResponseSchema>;
 
 // GitLab Wiki Attachment
+// Recent GitLab versions return a nested `link` object with `url` and `markdown`.
+// Older self-hosted instances may still return the flat `{commit_id, url}` shape.
+// We accept either; the formatter normalises into a single output shape.
 export const GitLabWikiAttachmentSchema = z.object({
   file_name: z.string(),
   file_path: z.string(),
@@ -350,7 +353,9 @@ export const GitLabWikiAttachmentSchema = z.object({
   link: z.object({
     url: z.string(),
     markdown: z.string()
-  })
+  }).optional(),
+  url: z.string().optional(),
+  commit_id: z.string().optional(),
 });
 
 export type GitLabWikiAttachment = z.infer<typeof GitLabWikiAttachmentSchema>;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -347,8 +347,10 @@ export const GitLabWikiAttachmentSchema = z.object({
   file_name: z.string(),
   file_path: z.string(),
   branch: z.string(),
-  commit_id: z.string(),
-  url: z.string().optional()
+  link: z.object({
+    url: z.string(),
+    markdown: z.string()
+  })
 });
 
 export type GitLabWikiAttachment = z.infer<typeof GitLabWikiAttachmentSchema>;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -559,6 +559,10 @@ export const UploadProjectWikiAttachmentSchema = z.object({
   project_id: z.string(),
   file_path: z.string(),
   content: z.string(),
+  // 'utf8' (default) treats `content` as text/raw bytes. 'base64' decodes
+  // `content` before upload — required to send binary files (PNG, PDF, etc.)
+  // through MCP's JSON-string parameter.
+  content_encoding: z.enum(['utf8', 'base64']).optional(),
   branch: z.string().optional()
 });
 
@@ -598,6 +602,7 @@ export const UploadGroupWikiAttachmentSchema = z.object({
   group_id: z.string(),
   file_path: z.string(),
   content: z.string(),
+  content_encoding: z.enum(['utf8', 'base64']).optional(),
   branch: z.string().optional()
 });
 

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -670,3 +670,58 @@ describe('Transport — CORS origin handling', () => {
     expect(res.headers['access-control-allow-origin']).toBeUndefined();
   });
 });
+
+describe('Transport — PAT + Streamable HTTP per-session factory (#62)', () => {
+  let port: number;
+  let factoryCalls = 0;
+
+  beforeAll(async () => {
+    port = 19800 + Math.floor(Math.random() * 100);
+    process.env.AUTH_MODE = 'pat';
+    process.env.CORS_ALLOW_ORIGINS = '';
+    factoryCalls = 0;
+    // Both `server` (static, signals PAT mode) AND `serverFactory` (per-session)
+    // are passed. The setupTransport contract treats this as "PAT with
+    // per-session factory" — the factory is invoked per session, the static
+    // server argument acts as a mode flag.
+    const staticServer = createTestServer('pat-mode');
+    await setupTransport(staticServer, {
+      port,
+      useStreamableHttp: true,
+      host: '127.0.0.1',
+      serverFactory: () => {
+        factoryCalls++;
+        return createTestServer(`session-${factoryCalls}`);
+      },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  afterAll(() => {
+    delete process.env.AUTH_MODE;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('invokes the factory once per session, without requiring an Authorization header', async () => {
+    const before = factoryCalls;
+    const init = (id: number) => JSON.stringify({
+      jsonrpc: '2.0', id, method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+    });
+    const headers = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      // No Authorization header: PAT-mode-with-factory must accept this.
+    };
+
+    const r1 = await request(port, 'POST', '/mcp', headers, init(1));
+    const r2 = await request(port, 'POST', '/mcp', headers, init(2));
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r1.headers['mcp-session-id']).toBeDefined();
+    expect(r2.headers['mcp-session-id']).toBeDefined();
+    expect(r1.headers['mcp-session-id']).not.toBe(r2.headers['mcp-session-id']);
+    expect(factoryCalls - before).toBe(2);
+  });
+});

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -200,6 +200,12 @@ export async function setupTransport(
     if (!serverFactory) {
       return server ? { server, bearerHash: null } : null;
     }
+    // If a static server is also provided, this is PAT mode with per-session
+    // factory (needed for streamable-http multi-session). No Bearer required.
+    if (server) {
+      return { server: serverFactory(''), bearerHash: null };
+    }
+    // OAuth mode: Bearer is mandatory
     const token = extractBearer(req);
     if (!token) return null;
     return { server: serverFactory(token), bearerHash: hashBearer(token) };


### PR DESCRIPTION
## Summary

Carries forward both bug fixes from #62 (@ecthelion77, Olivier Gintrand) with the corrections we need before merge: explicit binary-upload support, schema fallback for older GitLab, regression tests for both fixes, and a release commit on top.

This is a Path-B fixup PR per the maintainer pattern documented for fork PRs that need rebasing after main moved (0.7.0 → 0.7.1 shipped on 2026-05-18, in #62's response window). Olivier's commits are cherry-picked with authorship preserved.

## Commits

| SHA | Author | Subject |
|---|---|---|
| b64eff2 | Olivier Gintrand | fix: wiki attachment upload uses multipart/form-data (not JSON) |
| 918cb7a | Olivier Gintrand | fix: use per-session server factory in PAT + streamable-http mode |
| 04c08c9 | nalyk | fix(api): support binary wiki uploads via content_encoding parameter |
| 869b919 | nalyk | fix(schemas): accept both modern and legacy GitLab wiki attachment shapes |
| a5f6262 | nalyk | test: cover wiki multipart body, base64 encoding, and PAT+streamable factory |
| 4b2a409 | nalyk | chore(release): 0.7.2 |

Squash-merge will carry \`Co-authored-by: Olivier Gintrand <olivier.gintrand@forterro.com>\` so the contribution graph credits him correctly.

## Original fixes (Olivier)

### 1. Wiki attachment: JSON → multipart/form-data

\`uploadProjectWikiAttachment\` and \`uploadGroupWikiAttachment\` previously sent JSON with a base64 data URI, causing **400 on every call** against any GitLab version that follows the documented API. Now uses \`FormData\` + \`Blob\` per [GitLab docs](https://docs.gitlab.com/api/wikis/#upload-an-attachment-to-the-wiki).

\`GitLabWikiAttachmentSchema\` updated to match the actual response shape (\`link.{url, markdown}\`).

### 2. Per-session server factory in PAT + streamable-http mode

A single shared \`Server\` instance across streamable-http sessions raised \`"Already connected to a transport"\` on the second concurrent client and crashed the process. The \`serverFactory\` closure pattern is now applied to PAT mode when \`USE_SSE\` or \`USE_STREAMABLE_HTTP\` is set, so each session gets its own \`Server\`.

## Maintainer corrections

### A. \`content_encoding\` parameter for binary uploads (04c08c9)

The multipart fix removed the implicit base64-wrap path without offering callers a way to upload binary files. MCP parameters are JSON strings, so binary content can only travel as base64 — passing it raw into \`Blob([content])\` now uploads literal base64 ASCII text and silently corrupts the file server-side.

Adds explicit \`content_encoding?: 'utf8' | 'base64'\` to both upload tools:
- Default \`'utf8'\`: content treated as raw text/bytes (current behaviour for text uploads).
- \`'base64'\`: content base64-decoded into a Buffer before Blob wrap.

No automatic detection — base64 false-positives on alphanumeric text are not worth the silent-failure risk.

### B. Schema fallback for older self-hosted GitLab (869b919)

PR #62's schema change made \`link: { url, markdown }\` strict. Older self-hosted GitLab versions still return the legacy flat \`{commit_id, url}\` shape, which would throw a Zod parse error even though the upload succeeded server-side. \`link\` is now optional and \`url\`/\`commit_id\` are accepted as optional legacy fields. The formatter normalises into a single output shape.

### C. Regression tests (a5f6262)

- \`gitlab-api.test.ts\` (+143 lines): multipart body shape, content_encoding='base64' decodes raw bytes (verified with PNG signature), default treats content as text, parser accepts both modern and legacy response shapes, branch omission.
- \`transport.test.ts\` (+55 lines): PAT + Streamable HTTP per-session factory creates a new \`Server\` per session, no Authorization header required, two concurrent inits get distinct session IDs.

Test count: 79 → 86.

### D. Release 0.7.2 (4b2a409)

Version bump + CHANGELOG. Section structured as: \`### Fixed\` (Olivier's two), \`### Added\` (content_encoding), \`### Changed\` (MCP response field rename), \`### Compatibility\` (legacy GitLab fallback). LLM consumers parsing tool output get explicit signal about the field rename.

## Follow-up (not in this PR)

The \`setupTransport(server, options)\` API now has a tri-state — \`server\` + \`serverFactory\` both set means "PAT with per-session factory". Convention-only at runtime. A type-design-analyzer review flagged this and proposed a discriminated-union refactor (\`{ kind: 'pat-static' | 'pat-factory' | 'oauth' }\`). I'll open a separate issue for that refactor — it's pure type safety, no behaviour change.

## Verification

- \`npm run build\`: clean
- \`npm test\`: 86 passed (79 baseline + 7 new)
- \`npm audit\`: 0 vulnerabilities
- All authorship preserved: Olivier appears as Author on commits b64eff2 + 918cb7a

## Release ceremony

Merge this PR → create GitHub release v0.7.2 → publish.yml triggers OIDC npm publish, per the release-driven model (#43).