### PR TITLE
feat(e2e): comprehensive E2E test suite (reincarnation of #63 + maintainer corrections)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,17 @@
+# ---------------------------------------------------------------------------
+# Build & Publish — GitLab MCP Server
+#
+# Branch build model:
+#   - main push: always build → tag: sha-<short> + latest
+#   - branch push with [build] or [e2e] in commit message: build → tag: <branch>-<sha7>
+#   - tag push (v*): build → semver + latest + Helm chart
+#   - PR: validate only (lint, helm template)
+# ---------------------------------------------------------------------------
 name: "Build & Publish"
 
 on:
   push:
-    branches: [main]
+    branches: ["**"]
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -10,17 +19,17 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}  # yoda-digital/mcp-gitlab-server
+  IMAGE_NAME: ${{ github.repository }}
   CHART_NAME: gitlab-mcp
 
 permissions:
   contents: read
   packages: write
 
-# -------------------------------------------------------------------
-# Job 1 — Validate (runs on every push and PR)
-# -------------------------------------------------------------------
 jobs:
+  # -------------------------------------------------------------------
+  # Job 1 — Validate (runs on every push and PR)
+  # -------------------------------------------------------------------
   validate:
     runs-on: ubuntu-latest
     steps:
@@ -117,17 +126,60 @@ jobs:
             exit 1
           }
 
+      - name: Tool E2E coverage gate
+        run: ./scripts/check-tool-coverage.sh
+
   # -------------------------------------------------------------------
-  # Job 2 — Docker build + push (skipped on PRs)
+  # Job 2 — Docker build + push
+  #
+  # Runs when:
+  #   - Push to main (always)
+  #   - Push to branch with [build] or [e2e] in commit message
+  #   - Tag push (v*)
+  # Skipped on PRs and branch pushes without keyword.
   # -------------------------------------------------------------------
   docker:
     runs-on: ubuntu-latest
     needs: validate
-    if: github.event_name != 'pull_request'
+    if: |
+      github.event_name != 'pull_request' && (
+        github.ref == 'refs/heads/main' ||
+        github.ref_type == 'tag' ||
+        contains(github.event.head_commit.message, '[build]') ||
+        contains(github.event.head_commit.message, '[e2e]')
+      )
     outputs:
-      version: ${{ steps.meta.outputs.version }}
+      image-tag: ${{ steps.tags.outputs.primary }}
+      image-full: ${{ steps.tags.outputs.full }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHA7="${GITHUB_SHA::7}"
+
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            # Tag push: v1.2.3 → 1.2.3
+            VERSION="${GITHUB_REF_NAME#v}"
+            PRIMARY="$VERSION"
+            TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            # Main branch
+            PRIMARY="sha-${SHA7}"
+            TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${SHA7},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          else
+            # Feature branch: sanitize branch name
+            BRANCH="${GITHUB_REF_NAME}"
+            BRANCH_SAFE=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-50)
+            PRIMARY="${BRANCH_SAFE}-${SHA7}"
+            TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${PRIMARY}"
+          fi
+
+          echo "primary=$PRIMARY" >> "$GITHUB_OUTPUT"
+          echo "full=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${PRIMARY}" >> "$GITHUB_OUTPUT"
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          echo "📦 Image tags: $TAGS"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -139,27 +191,48 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # On tag push: v1.2.3 -> 1.2.3 + latest
-            type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
-            # On main push (no tag): sha-<short>
-            type=sha,prefix=,enable=${{ github.ref_type != 'tag' }}
-
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Compute E2E image tags
+        id: e2e-tags
+        run: |
+          PRIMARY="${{ steps.tags.outputs.primary }}"
+          E2E_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-e2e"
+
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            E2E_TAGS="${E2E_IMAGE}:${PRIMARY},${E2E_IMAGE}:latest"
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            E2E_TAGS="${E2E_IMAGE}:${PRIMARY},${E2E_IMAGE}:latest"
+          else
+            E2E_TAGS="${E2E_IMAGE}:${PRIMARY}"
+          fi
+
+          echo "tags=$E2E_TAGS" >> "$GITHUB_OUTPUT"
+          echo "📦 E2E image tags: $E2E_TAGS"
+
+      - name: Build and push E2E image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./e2e
+          file: ./e2e/Dockerfile
+          push: true
+          tags: ${{ steps.e2e-tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.description=E2E test runner for GitLab MCP Server
+          cache-from: type=gha,scope=e2e
+          cache-to: type=gha,mode=max,scope=e2e
 
   # -------------------------------------------------------------------
   # Job 3 — Helm package + push (only on tags)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,242 @@
+# ---------------------------------------------------------------------------
+# E2E tests — GitLab MCP Server
+#
+# Triggered AFTER the "Build & Publish" workflow completes. Uses the Docker
+# image already built by build.yml — no duplicate builds.
+#
+# Trigger model:
+#   - workflow_run: fires after build.yml. Gates itself:
+#       • main → always run
+#       • branch → only if commit message had [e2e]
+#   - workflow_dispatch: manual trigger (uses latest main image)
+#
+# GitLab CE uses a pre-warmed image (built by warm-gitlab.yml) for faster boot.
+# ---------------------------------------------------------------------------
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'MCP image tag to test (default: latest)'
+        default: 'latest'
+        type: string
+  workflow_run:
+    workflows: ["Build & Publish"]
+    types: [completed]
+
+jobs:
+  # -------------------------------------------------------------------
+  # Gate — decide whether to run E2E
+  # -------------------------------------------------------------------
+  should-run:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success')
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+      image-tag: ${{ steps.check.outputs.image_tag }}
+    steps:
+      - name: Check trigger conditions
+        id: check
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+            echo "✅ Manual dispatch — using tag: ${{ inputs.image_tag }}"
+          elif [[ "$HEAD_BRANCH" == "main" ]]; then
+            SHA7="${HEAD_SHA::7}"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "image_tag=sha-${SHA7}" >> "$GITHUB_OUTPUT"
+            echo "✅ Main branch — using tag: sha-${SHA7}"
+          elif echo "$HEAD_MESSAGE" | grep -qF '[e2e]'; then
+            SHA7="${HEAD_SHA::7}"
+            BRANCH_SAFE=$(echo "$HEAD_BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-50)
+            TAG="${BRANCH_SAFE}-${SHA7}"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "✅ Branch with [e2e] — using tag: ${TAG}"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "image_tag=" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Skipping E2E — no [e2e] keyword in commit message"
+          fi
+
+  # -------------------------------------------------------------------
+  # Run E2E tests against ephemeral GitLab CE + MCP from Docker
+  # -------------------------------------------------------------------
+  e2e:
+    name: End-to-end tests
+    needs: should-run
+    if: needs.should-run.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    env:
+      GITLAB_URL: http://localhost:8080
+      GITLAB_ROOT_PASSWORD: 'E2eTestPassword1!'
+      MCP_SERVER_URL: http://localhost:3000
+      MCP_IMAGE: ghcr.io/${{ github.repository }}:${{ needs.should-run.outputs.image-tag }}
+      E2E_IMAGE: ghcr.io/${{ github.repository }}-e2e:${{ needs.should-run.outputs.image-tag }}
+      GITLAB_WARM_IMAGE: ghcr.io/${{ github.repository }}/gitlab-ce-warm:latest
+      GITLAB_COLD_IMAGE: gitlab/gitlab-ce:latest
+
+    steps:
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull MCP and E2E images
+        run: |
+          echo "📦 Pulling MCP server image: $MCP_IMAGE"
+          docker pull "$MCP_IMAGE"
+          echo "📦 Pulling E2E test runner image: $E2E_IMAGE"
+          docker pull "$E2E_IMAGE"
+
+      - name: Pull GitLab image (warm or cold fallback)
+        id: gitlab-image
+        run: |
+          echo "🔍 Trying pre-warmed GitLab image..."
+          if docker pull "$GITLAB_WARM_IMAGE" 2>/dev/null; then
+            echo "⚡ Using pre-warmed GitLab image"
+            echo "image=$GITLAB_WARM_IMAGE" >> "$GITHUB_OUTPUT"
+            echo "warm=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "📦 Warm image not available, pulling cold GitLab CE..."
+            docker pull "$GITLAB_COLD_IMAGE"
+            echo "image=$GITLAB_COLD_IMAGE" >> "$GITHUB_OUTPUT"
+            echo "warm=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Start GitLab CE container
+        run: |
+          # external_url uses port 80 inside container to avoid nginx/puma conflict.
+          # Host maps 8080 → container 80. GITLAB_URL env uses localhost:8080.
+          OMNIBUS_CONFIG="
+            external_url 'http://gitlab.local';
+            gitlab_rails['initial_root_password'] = '${{ env.GITLAB_ROOT_PASSWORD }}';
+            gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0', '::/0'];
+            prometheus_monitoring['enable'] = false;
+            registry['enable'] = false;
+            sidekiq['concurrency'] = 2;
+            puma['worker_processes'] = 1;
+            puma['min_threads'] = 1;
+            puma['max_threads'] = 2;
+            postgresql['shared_buffers'] = '128MB';
+            postgresql['max_connections'] = 50;
+            gitlab_rails['gitlab_shell_ssh_port'] = 2222;
+          "
+
+          docker run -d \
+            --name gitlab \
+            --shm-size 1g \
+            --tmpfs /var/log/gitlab:rw,noexec,nosuid,size=256m \
+            -p 8080:80 \
+            -e GITLAB_OMNIBUS_CONFIG="$OMNIBUS_CONFIG" \
+            "${{ steps.gitlab-image.outputs.image }}"
+
+          echo "✅ GitLab container started (warm=${{ steps.gitlab-image.outputs.warm }})"
+
+      - name: Wait for GitLab readiness
+        run: |
+          if [[ "${{ steps.gitlab-image.outputs.warm }}" == "true" ]]; then
+            BUDGET=300  # 5 min for warm image
+            echo "⏳ Waiting for GitLab (warm image — expecting ~2 min)..."
+          else
+            BUDGET=900  # 15 min for cold image
+            echo "⏳ Waiting for GitLab (cold image — expecting ~8-12 min)..."
+          fi
+
+          SECONDS=0
+          until curl -sf http://localhost:8080/-/readiness > /dev/null 2>&1; do
+            if [ $SECONDS -gt $BUDGET ]; then
+              echo "❌ GitLab did not become ready within budget (${BUDGET}s)"
+              docker logs gitlab --tail 80
+              exit 1
+            fi
+            sleep 5
+            echo "   ...waiting (${SECONDS}s elapsed)"
+          done
+          echo "✅ GitLab is ready (took ${SECONDS}s)"
+
+      - name: Provision GitLab fixtures (via E2E image)
+        run: |
+          mkdir -p fixtures && chmod 777 fixtures
+          docker run --rm --network host \
+            -e GITLAB_URL=${{ env.GITLAB_URL }} \
+            -e GITLAB_ROOT_PASSWORD=${{ env.GITLAB_ROOT_PASSWORD }} \
+            -v ${{ github.workspace }}/fixtures:/app/fixtures \
+            "$E2E_IMAGE" provision
+
+      - name: Start MCP server (from Docker image)
+        run: |
+          GITLAB_TOKEN=$(jq -r .token fixtures/fixtures.json)
+
+          docker run -d \
+            --name mcp-server \
+            --network host \
+            -e PORT=3000 \
+            -e USE_STREAMABLE_HTTP=true \
+            -e GITLAB_PERSONAL_ACCESS_TOKEN="$GITLAB_TOKEN" \
+            -e GITLAB_API_URL=http://localhost:8080/api/v4 \
+            -e NODE_ENV=test \
+            "$MCP_IMAGE"
+
+          echo "⏳ Waiting for MCP server..."
+          timeout 30 bash -c '
+            until curl -sf http://localhost:3000/livez > /dev/null 2>&1; do
+              sleep 1
+            done
+          '
+          echo "✅ MCP server is ready"
+
+      - name: Run E2E tests (via E2E image)
+        run: |
+          mkdir -p reports && chmod 777 reports
+          docker run --rm --network host \
+            -e MCP_SERVER_URL=${{ env.MCP_SERVER_URL }} \
+            -e GITLAB_URL=${{ env.GITLAB_URL }} \
+            -e GITLAB_ROOT_PASSWORD=${{ env.GITLAB_ROOT_PASSWORD }} \
+            -v ${{ github.workspace }}/fixtures:/app/fixtures \
+            -v ${{ github.workspace }}/reports:/app/reports \
+            "$E2E_IMAGE" test
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-report
+          path: reports/
+          retention-days: 7
+
+      - name: Teardown fixtures (via E2E image)
+        if: always()
+        run: |
+          docker run --rm --network host \
+            -e GITLAB_URL=${{ env.GITLAB_URL }} \
+            -e GITLAB_ROOT_PASSWORD=${{ env.GITLAB_ROOT_PASSWORD }} \
+            -v ${{ github.workspace }}/fixtures:/app/fixtures \
+            "$E2E_IMAGE" teardown || true
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== MCP Server logs ==="
+          docker logs mcp-server --tail 50 2>&1 || true
+          echo ""
+          echo "=== GitLab logs ==="
+          docker logs gitlab --tail 50 2>&1 || true
+
+      - name: Stop containers
+        if: always()
+        run: |
+          docker rm -f mcp-server 2>/dev/null || true
+          docker rm -f gitlab 2>/dev/null || true

--- a/.github/workflows/warm-gitlab.yml
+++ b/.github/workflows/warm-gitlab.yml
@@ -1,0 +1,184 @@
+# ---------------------------------------------------------------------------
+# Pre-warm GitLab CE image for E2E tests
+#
+# This workflow boots a cold GitLab CE instance, waits for full initialization
+# (database migrations, service startup), then commits the container state to
+# a new "warm" image. The warm image boots in ~2 min vs 8-12 min cold.
+#
+# Schedule: weekly (Sunday 03:00 UTC) to keep the image fresh.
+# Manual: workflow_dispatch to rebuild on demand (e.g. after GitLab version bump).
+# ---------------------------------------------------------------------------
+name: Warm GitLab Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitlab_version:
+        description: 'GitLab CE version to warm'
+        default: '18.11.2-ce.0'
+        type: string
+  schedule:
+    # Weekly rebuild — Sunday 03:00 UTC
+    - cron: '0 3 * * 0'
+
+env:
+  REGISTRY: ghcr.io
+  GITLAB_VERSION: ${{ inputs.gitlab_version || '18.11.2-ce.0' }}
+  WARM_IMAGE_NAME: ${{ github.repository }}/gitlab-ce-warm
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  warm:
+    name: Build pre-warmed GitLab CE image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Pull cold GitLab CE image
+        run: |
+          echo "📦 Pulling gitlab/gitlab-ce:${{ env.GITLAB_VERSION }}..."
+          docker pull "gitlab/gitlab-ce:${{ env.GITLAB_VERSION }}"
+
+      - name: Boot GitLab CE (cold start)
+        run: |
+          # external_url uses port 80 (default inside container) to avoid
+          # nginx/puma port conflicts. Host maps 8080 → container 80.
+          docker run -d \
+            --name gitlab-warm \
+            --shm-size 1g \
+            -p 8080:80 \
+            -e GITLAB_OMNIBUS_CONFIG="
+              external_url 'http://gitlab.local';
+              gitlab_rails['initial_root_password'] = 'E2eTestPassword1!';
+              gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0', '::/0'];
+              prometheus_monitoring['enable'] = false;
+              registry['enable'] = false;
+              sidekiq['concurrency'] = 2;
+              puma['worker_processes'] = 1;
+              puma['min_threads'] = 1;
+              puma['max_threads'] = 2;
+              postgresql['shared_buffers'] = '128MB';
+              postgresql['max_connections'] = 50;
+              gitlab_rails['gitlab_shell_ssh_port'] = 2222;
+            " \
+            "gitlab/gitlab-ce:${{ env.GITLAB_VERSION }}"
+
+          echo "⏳ Waiting for cold boot (this takes 8-12 min)..."
+
+      - name: Wait for GitLab readiness
+        run: |
+          SECONDS=0
+          until curl -sf http://localhost:8080/-/readiness > /dev/null 2>&1; do
+            if [ $SECONDS -gt 1200 ]; then
+              echo "❌ GitLab did not become ready within 20 minutes"
+              docker logs gitlab-warm --tail 80
+              exit 1
+            fi
+            sleep 10
+            echo "   ...waiting (${SECONDS}s elapsed)"
+          done
+          echo "✅ GitLab is ready (took ${SECONDS}s)"
+
+      - name: Verify GitLab API is functional
+        run: |
+          # In GitLab 17.x, /api/v4/version requires auth — a 401 proves the
+          # API layer is alive and correctly enforcing authentication.
+          # Any 2xx or 401 = API functional. 5xx or no response = broken.
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            "http://localhost:8080/api/v4/version")
+          echo "API /version returned: $HTTP_CODE"
+          if [[ "$HTTP_CODE" =~ ^5 ]] || [[ "$HTTP_CODE" == "000" ]]; then
+            echo "❌ GitLab API not functional (got $HTTP_CODE)"
+            exit 1
+          fi
+          echo "✅ API responding (auth enforced)"
+
+      - name: Gracefully stop GitLab services
+        run: |
+          # Stop services cleanly before committing (sidekiq may timeout — tolerate)
+          docker exec gitlab-warm gitlab-ctl stop || true
+          # Wait for services to stop
+          sleep 5
+          echo "✅ Services stopped"
+
+      - name: Commit warm image
+        run: |
+          WARM_TAG="${{ env.REGISTRY }}/${{ env.WARM_IMAGE_NAME }}:${{ env.GITLAB_VERSION }}"
+          echo "📸 Committing container state as: $WARM_TAG"
+
+          # Detect the original CMD from the source image
+          ORIGINAL_CMD=$(docker inspect "gitlab/gitlab-ce:${{ env.GITLAB_VERSION }}" --format '{{json .Config.Cmd}}')
+          echo "   Original CMD: $ORIGINAL_CMD"
+
+          docker commit \
+            --change="CMD $ORIGINAL_CMD" \
+            --message "Pre-warmed GitLab CE ${{ env.GITLAB_VERSION }} (migrations done, services initialized)" \
+            gitlab-warm \
+            "$WARM_TAG"
+
+          echo "warm_tag=$WARM_TAG" >> "$GITHUB_ENV"
+          echo "✅ Image committed"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push warm image
+        run: |
+          LATEST_TAG="${{ env.REGISTRY }}/${{ env.WARM_IMAGE_NAME }}:latest"
+          docker tag "${{ env.warm_tag }}" "$LATEST_TAG"
+          echo "🚀 Pushing ${{ env.warm_tag }}..."
+          docker push "${{ env.warm_tag }}"
+          echo "🚀 Pushing $LATEST_TAG..."
+          docker push "$LATEST_TAG"
+          echo "✅ Warm image pushed (versioned + latest)"
+
+      - name: Verify warm image boots fast
+        run: |
+          # Stop the old container
+          docker rm -f gitlab-warm
+
+          echo "🔥 Testing warm image boot time..."
+          docker run -d \
+            --name gitlab-warm-test \
+            --shm-size 1g \
+            -p 8081:80 \
+            -e GITLAB_OMNIBUS_CONFIG="
+              external_url 'http://gitlab.local';
+              gitlab_rails['initial_root_password'] = 'E2eTestPassword1!';
+              gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0', '::/0'];
+              prometheus_monitoring['enable'] = false;
+              registry['enable'] = false;
+              sidekiq['concurrency'] = 2;
+              puma['worker_processes'] = 1;
+              puma['min_threads'] = 1;
+              puma['max_threads'] = 2;
+              postgresql['shared_buffers'] = '128MB';
+              postgresql['max_connections'] = 50;
+            " \
+            "${{ env.warm_tag }}"
+
+          SECONDS=0
+          until curl -sf http://localhost:8081/-/readiness > /dev/null 2>&1; do
+            if [ $SECONDS -gt 300 ]; then
+              echo "⚠️ Warm image took >5 min — not much faster than cold"
+              docker logs gitlab-warm-test --tail 30
+              break
+            fi
+            sleep 5
+          done
+          echo "🏁 Warm image boot time: ${SECONDS}s"
+
+          docker rm -f gitlab-warm-test
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f gitlab-warm 2>/dev/null || true
+          docker rm -f gitlab-warm-test 2>/dev/null || true

--- a/.github/workflows/warm-gitlab.yml
+++ b/.github/workflows/warm-gitlab.yml
@@ -123,21 +123,36 @@ jobs:
           echo "✅ Image committed"
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push warm image
+        # NOTE: the committed image carries the public test password
+        # ('E2eTestPassword1!') hashed inside the warm Postgres DB. That's
+        # intentional and harmless — it's a known public test credential
+        # documented in e2e/README.md, NOT a real secret. Do not bake any
+        # real secret into this workflow.
+        #
+        # The :latest tag is only updated by the scheduled run (cron). A
+        # workflow_dispatch with an older GITLAB_VERSION pushes only the
+        # versioned tag, so :latest can't accidentally regress.
         run: |
-          LATEST_TAG="${{ env.REGISTRY }}/${{ env.WARM_IMAGE_NAME }}:latest"
-          docker tag "${{ env.warm_tag }}" "$LATEST_TAG"
           echo "🚀 Pushing ${{ env.warm_tag }}..."
           docker push "${{ env.warm_tag }}"
-          echo "🚀 Pushing $LATEST_TAG..."
-          docker push "$LATEST_TAG"
-          echo "✅ Warm image pushed (versioned + latest)"
+
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            LATEST_TAG="${{ env.REGISTRY }}/${{ env.WARM_IMAGE_NAME }}:latest"
+            docker tag "${{ env.warm_tag }}" "$LATEST_TAG"
+            echo "🚀 Scheduled run — also pushing $LATEST_TAG..."
+            docker push "$LATEST_TAG"
+          else
+            echo "ℹ️  workflow_dispatch — skipping :latest tag update to prevent regression"
+          fi
+
+          echo "✅ Warm image pushed"
 
       - name: Verify warm image boots fast
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+E2E test infrastructure (reincarnation of #63 by @ecthelion77, Olivier Gintrand) plus three pre-existing schema bugs the suite surfaced on first run against GitLab CE 18.x.
+
+### Added
+
+- **End-to-end test suite** under `e2e/` — 81 tests covering all 86 MCP tools
+  against a real GitLab CE container. 76 pass + 5 Premium-only skipped on a
+  fresh GitLab volume. Originally proposed in #63 by @ecthelion77; reincarnated
+  by maintainer onto current `main` with corrections (see `Internal` below).
+- **`.github/workflows/e2e.yml`** — runs the E2E suite after the build workflow
+  completes, using a pre-warmed GitLab CE image.
+- **`.github/workflows/warm-gitlab.yml`** — weekly pre-warm of a GitLab CE image
+  with migrations already applied, cutting E2E boot time from 8-12 min cold to
+  ~2 min. Manual `workflow_dispatch` available for ad-hoc rebuilds.
+- **`scripts/check-tool-coverage.sh`** — coverage gate wired into `build.yml`
+  that fails the build if a new tool is added to `src/index.ts` without a
+  corresponding E2E test. Premium-only tools (group wiki) whitelisted.
+- **`GITLAB_HOST_PORT` env override** in `e2e/docker-compose.yml` for local
+  contributors whose host port 8080 is occupied by other services.
+
+### Fixed
+
+- **`GitLabRepositorySchema` now declares `path_with_namespace` and `path`** —
+  present in every `/projects` response from GitLab but Zod was silently
+  stripping them, so tool consumers that relied on them (including the
+  `search_repositories` E2E test) saw `undefined`. Pre-existing bug on `main`,
+  surfaced by the reincarnated suite.
+- **`approveMergeRequest` / `unapproveMergeRequest` no longer parse responses
+  as full MergeRequest objects** — the `/merge_requests/:iid/approve` and
+  `/unapprove` endpoints in GitLab CE return a small approval-state object,
+  not the full MR. The old code threw `Invalid arguments: id, iid, ... required`
+  on every call. New schema `MergeRequestApprovalStateSchema` parses both
+  variants and tolerates the 204 No Content return from CE on unapprove.
+- **`WikiPageFormatEnum` accepts `'plaintext'`** — GitLab CE 18.x returns
+  `'plaintext'` on wiki pages created via API without an explicit format,
+  in addition to the 4 documented values. Enum was rejecting the response.
+
+### Internal
+
+- **Maintainer corrections applied during reincarnation of #63** — node:22-alpine
+  digest pin in `e2e/Dockerfile`; `gitlab/gitlab-ce:18.11.3-ce.0` pin in
+  docker-compose (was `:latest`); `external_url 'http://gitlab.local'` (nominal
+  hostname) so nginx listens on container port 80 matching the port mapping;
+  `monitoring_whitelist = ['0.0.0.0/0', '::/0']` so host-side
+  `wait-for-gitlab.sh` can poll `/-/readiness` through the docker bridge;
+  `FIXTURES_DIR` default changed from absolute `/app/fixtures` to relative
+  `./fixtures` so host runs work; `ToolResult` type narrowed from `any` to a
+  shaped optional-content union; coverage-script regex tightened to `.callTool(`
+  context to eliminate 5 false positives; `.dockerignore` added; `warm-gitlab.yml`
+  permissions and `:latest` push gating hardened. Full per-commit detail on the
+  reincarnation PR.
+
+### Credits
+
+- E2E suite design and ~80% of the implementation: @ecthelion77 (Olivier Gintrand).
+  Cherry-picked with authorship preserved on each of his 5 commits; the squash
+  merge to `main` carries a `Co-authored-by:` trailer.
 
 ## [0.7.2] - 2026-05-18
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,60 @@ describe('create_issue tool', () => {
 });
 ```
 
+### Running the E2E suite locally
+
+The repo ships a comprehensive E2E suite under `e2e/` that runs against a real GitLab CE container. CI runs it automatically; the procedure below is for local development.
+
+**Prerequisites:** Docker, Node 22+, ~6 GB free disk, ~8-12 min for a cold GitLab CE boot.
+
+**One-time setup per run:**
+
+```bash
+cd e2e
+
+# If host port 8080 is occupied (e.g. by code-server), pick another:
+# export GITLAB_HOST_PORT=18080
+
+docker compose up -d gitlab
+GITLAB_URL=http://localhost:${GITLAB_HOST_PORT:-8080} \
+  GITLAB_READY_TIMEOUT=900 \
+  bash src/scripts/wait-for-gitlab.sh
+
+npm ci
+export GITLAB_URL=http://localhost:${GITLAB_HOST_PORT:-8080}
+export GITLAB_ROOT_PASSWORD='E2eTestPassword1!'
+npm run provision
+```
+
+**Start the MCP server in another terminal:**
+
+```bash
+export GITLAB_PERSONAL_ACCESS_TOKEN=$(jq -r .token e2e/fixtures/fixtures.json)
+export GITLAB_API_URL=http://localhost:${GITLAB_HOST_PORT:-8080}/api/v4
+export USE_STREAMABLE_HTTP=true
+node dist/index.js
+```
+
+**Run the tests:**
+
+```bash
+cd e2e
+export MCP_SERVER_URL=http://127.0.0.1:3000
+npm test
+```
+
+**Teardown — required between runs:**
+
+```bash
+docker compose down -v   # destroys the GitLab volume
+```
+
+The suite is **not idempotent today** — re-running `npm test` without resetting the volume causes ~50% failures from `409 Conflict` on duplicated POST entities. Always `docker compose down -v` between runs locally. CI is unaffected because it boots a fresh GitLab per workflow run.
+
+### Adding a new tool
+
+When you add a new MCP tool to `src/index.ts`, you MUST also add an E2E test in the appropriate domain file under `e2e/src/tests/`. The coverage gate (`scripts/check-tool-coverage.sh`) wired into `build.yml` will fail the build if a registered tool has no E2E coverage. Premium-only tools (group wikis) can be whitelisted in the script's `EXCLUDED_TOOLS` array with a comment explaining why.
+
 ---
 
 ## 📚 Documentation
@@ -265,6 +319,56 @@ Before submitting:
 - **Documentation** — Is it documented?
 - **Code Quality** — Clean, readable, maintainable?
 - **Breaking Changes** — Are they necessary? Documented?
+
+---
+
+## 🔄 Maintainer rebase pattern (Path B)
+
+When a contributor's PR sits idle for an extended period and `main` drifts (security batches, releases, dependent fixes), the fair move per project policy is for **the maintainer to absorb the rebase cost rather than push it onto the contributor**. This protects contributor velocity from churn the maintainer caused.
+
+The pattern (verified on PRs #62 → #80 and #63 → #81):
+
+1. **Fetch the contributor's branch locally**:
+   ```bash
+   git fetch origin pull/<N>/head:pr-<N>-incoming
+   ```
+
+2. **Create a fresh branch from current `main`**:
+   ```bash
+   git checkout -b feat/<topic>-reincarnation main
+   ```
+
+3. **Cherry-pick the contributor's commits with `-C` so their authorship is preserved**:
+   ```bash
+   git cherry-pick -C <sha>
+   ```
+   Drop commits whose contents are already on `main` via a different path (e.g. an earlier reincarnation). Verify each cherry-pick doesn't restage `src/` files that should stay at main's version.
+
+4. **Apply maintainer corrections as additional commits** in your own name. One commit per finding, conventional-commits style.
+
+5. **Open a new PR** with a title indicating the relationship to the original. PR body MUST include:
+   - Explicit credit to the original contributor and the original PR number
+   - A line-by-line list of changes vs the original (so the contributor can audit your corrections)
+   - A `Co-authored-by: Name <email>` trailer at the bottom (used by the squash merge to preserve credit on the contribution graph)
+
+6. **Merge the new PR**:
+   ```bash
+   gh pr merge <N> --squash --admin --delete-branch
+   ```
+
+7. **Close the original PR** with a credit comment (NOT via the auto-close `Closes #N` keyword — that path silently drops the comment):
+   ```bash
+   gh pr comment <original-N> --body "<credit + explanation>"
+   gh pr close <original-N>
+   ```
+
+8. **Verify `Co-authored-by:` landed in main**:
+   ```bash
+   git show --no-patch --format='%B' <merge-sha> | grep 'Co-authored-by'
+   ```
+   If missing, the public promise to the contributor has been silently broken — fix immediately (the merge commit can be amended or a follow-up commit can add explicit credit).
+
+The discipline is non-negotiable: a public commit-message promise to a contributor is load-bearing trust. Verify integrity before declaring the reincarnation complete.
 
 ---
 

--- a/e2e/.dockerignore
+++ b/e2e/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.git
+.gitignore
+*.log
+fixtures.json
+fixtures/
+.env
+.env.*
+docker-compose.yml
+README.md

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+reports/
+fixtures.json

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,82 @@
+# ---------------------------------------------------------------------------
+# GitLab MCP Server — E2E Test Runner
+#
+# Portable image to run E2E tests against any GitLab + MCP server.
+# Usage:
+#   docker run --rm --network host \
+#     -e MCP_SERVER_URL=http://localhost:3000 \
+#     -e GITLAB_URL=http://localhost:8080 \
+#     -e GITLAB_ROOT_PASSWORD=secret \
+#     ghcr.io/<repo>-e2e:<tag> [provision|test|teardown|all]
+# ---------------------------------------------------------------------------
+
+FROM node:24-alpine
+
+WORKDIR /app
+
+# Install curl for health-check scripts
+RUN apk add --no-cache curl bash jq
+
+# Install dependencies
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Copy test sources and helpers
+COPY tsconfig.json vitest.config.ts ./
+COPY src ./src
+
+# Default environment (override at runtime)
+ENV GITLAB_URL=http://gitlab:80
+ENV GITLAB_ROOT_PASSWORD="E2eTestPassword1!"
+ENV GITLAB_TOKEN=""
+ENV MCP_SERVER_URL=http://mcp-server:3000
+ENV MCP_TRANSPORT=streamable-http
+ENV NODE_ENV=test
+
+COPY <<'EOF' /app/entrypoint.sh
+#!/bin/bash
+set -e
+
+COMMAND="${1:-all}"
+
+case "$COMMAND" in
+  provision)
+    echo "📋 Provisioning GitLab fixtures..."
+    npx tsx src/scripts/provision-fixtures.ts
+    ;;
+  test)
+    echo "🧪 Running E2E tests..."
+    npm test
+    ;;
+  teardown)
+    echo "🧹 Tearing down fixtures..."
+    npx tsx src/scripts/teardown-fixtures.ts || true
+    ;;
+  all)
+    echo "🚀 Full E2E run: provision → test → teardown"
+    npx tsx src/scripts/provision-fixtures.ts
+    npm test
+    EXIT_CODE=$?
+    npx tsx src/scripts/teardown-fixtures.ts || true
+    exit $EXIT_CODE
+    ;;
+  wait)
+    echo "⏳ Waiting for GitLab readiness..."
+    ./src/scripts/wait-for-gitlab.sh
+    ;;
+  *)
+    echo "Unknown command: $COMMAND"
+    echo "Usage: docker run <image> [provision|test|teardown|all|wait]"
+    exit 1
+    ;;
+esac
+EOF
+
+RUN chmod +x /app/entrypoint.sh
+
+# Run as non-root
+RUN chown -R node:node /app
+USER node
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["all"]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -10,7 +10,7 @@
 #     ghcr.io/<repo>-e2e:<tag> [provision|test|teardown|all]
 # ---------------------------------------------------------------------------
 
-FROM node:24-alpine
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920
 
 WORKDIR /app
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,117 @@
+# End-to-End Tests
+
+Full MCP protocol-level integration tests for the GitLab MCP Server. Tests
+every tool against a real, ephemeral GitLab CE instance — no mocks.
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                   GitHub Actions Runner                       │
+│                                                              │
+│  ┌──────────────┐    MCP/HTTP     ┌──────────────────────┐  │
+│  │  E2E Runner  │ ──────────────► │  MCP Server (SUT)    │  │
+│  │  (Vitest +   │                 │  node dist/index.js  │  │
+│  │   MCP SDK)   │                 └──────────┬───────────┘  │
+│  └──────────────┘                            │ GitLab API   │
+│                                              ▼              │
+│                              ┌───────────────────────────┐  │
+│                              │  GitLab CE (service)      │  │
+│                              │  Ephemeral — fresh state  │  │
+│                              └───────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## What's Tested
+
+| Domain | Tools | Tests |
+|--------|-------|-------|
+| Repository | `search_repositories`, `create_repository`, `get_file_contents`, `create_or_update_file`, `push_files`, `get_repository_tree`, `list_commits`, `list_branches`, `create_branch`, `delete_branch`, `compare_branches`, `list_tags`, `create_tag`, `fork_repository` | 12 |
+| Issues | `list_issues`, `create_issue`, `update_issue`, `create_issue_note`, `list_issue_notes`, `list_issue_discussions` | 6 |
+| Merge Requests | `list_merge_requests`, `create_merge_request`, `update_merge_request`, `get_merge_request_changes`, `get_merge_request_commits`, `approve_merge_request`, `unapprove_merge_request`, `list_merge_request_notes`, `create_merge_request_note`, `update_merge_request_note`, `list_merge_request_discussions`, `create_merge_request_discussion`, `rebase_merge_request`, `merge_merge_request` | 14 |
+| Wiki | `list_project_wiki_pages`, `get_project_wiki_page`, `create_project_wiki_page`, `edit_project_wiki_page`, `delete_project_wiki_page`, `list_group_wiki_pages`, `get_group_wiki_page`, `create_group_wiki_page`, `edit_group_wiki_page`, `delete_group_wiki_page` | 10 |
+| Pipelines & Jobs | `list_pipelines`, `get_pipeline`, `trigger_pipeline`, `cancel_pipeline`, `list_pipeline_jobs`, `get_job` | 6 |
+| Labels & Milestones | `list_labels`, `create_label`, `update_label`, `list_milestones`, `create_milestone`, `update_milestone` | 6 |
+| Members | `list_project_members`, `list_group_members` | 2 |
+| Users & Groups | `get_current_user`, `list_users`, `get_user`, `list_groups`, `get_group`, `list_group_subgroups`, `create_group`, `update_group`, `delete_group`, `list_group_projects`, `get_project`, `update_project`, `get_project_events` | 13 |
+| Branch Protection | `list_protected_branches`, `protect_branch`, `unprotect_branch` | 3 |
+| Environments & Releases | `list_environments`, `list_releases`, `create_release` | 3 |
+
+**Total: ~75 tests covering all 86 tools** (some tools share test cases via roundtrips).
+
+## Prerequisites
+
+- Node.js 24+
+- Docker (for local development with docker-compose)
+
+## Local Development
+
+```bash
+# Start GitLab CE (takes ~3 minutes to boot)
+docker compose -f e2e/docker-compose.yml up -d gitlab
+
+# Wait for readiness
+e2e/src/scripts/wait-for-gitlab.sh
+
+# Install E2E dependencies
+cd e2e && npm ci
+
+# Provision test fixtures (creates group, project, issues, MR, wiki, etc.)
+export GITLAB_URL=http://localhost:8080
+export GITLAB_ROOT_PASSWORD='E2eTestPassword1!'
+npm run provision
+
+# Start the MCP server (in another terminal)
+export GITLAB_URL=http://localhost:8080
+export GITLAB_PERSONAL_ACCESS_TOKEN=$(jq -r .token e2e/fixtures.json)
+export USE_STREAMABLE_HTTP=true
+npm start
+
+# Run E2E tests
+cd e2e
+export MCP_SERVER_URL=http://localhost:3000
+npm test
+
+# Teardown (optional — deletes test data from GitLab)
+npm run teardown
+```
+
+## CI Workflow
+
+The E2E tests run automatically via `.github/workflows/e2e.yml`:
+- **Trigger**: Push to `main` (when `e2e/` or `src/` change), PRs, or manual dispatch
+- **GitLab CE**: Runs as a GitHub Actions service container (ephemeral, ~3 min boot)
+- **No shared runners**: Uses free `ubuntu-latest` — no GitLab.com runners needed
+- **Artifacts**: JUnit XML report uploaded for each run
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GITLAB_URL` | `http://localhost:8080` | GitLab instance URL |
+| `GITLAB_ROOT_PASSWORD` | `E2eTestPassword1!` | Root password for provisioning |
+| `MCP_SERVER_URL` | `http://localhost:3000` | MCP server endpoint |
+| `GITLAB_READY_TIMEOUT` | `300` | Seconds to wait for GitLab boot |
+
+## Docker Image (for external use)
+
+The E2E runner is packaged as a standalone Docker image for use in other CI
+systems (e.g., Kargo analysis templates):
+
+```bash
+docker build -t gitlab-mcp-e2e:latest -f e2e/Dockerfile .
+
+docker run --rm \
+  -e GITLAB_URL=https://my-gitlab.example.com \
+  -e GITLAB_TOKEN=glpat-xxxx \
+  -e MCP_SERVER_URL=http://mcp-server:3000 \
+  gitlab-mcp-e2e:latest
+```
+
+## Design Decisions
+
+1. **Real MCP protocol** — Tests use `@modelcontextprotocol/sdk` Client with `StreamableHTTPClientTransport`. No HTTP shortcuts.
+2. **No mocks** — Every test hits the real GitLab API through the MCP server. Catches serialization bugs, schema mismatches, and API version regressions.
+3. **Fixture-based** — A provisioning script seeds GitLab with deterministic test data. Tests are order-independent within a file.
+4. **Ephemeral GitLab** — Each CI run gets a fresh GitLab CE instance. No state leaks between runs.
+5. **Same toolchain** — Vitest + TypeScript, consistent with the unit test setup.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,11 +16,38 @@ every tool against a real, ephemeral GitLab CE instance — no mocks.
 │  └──────────────┘                            │ GitLab API   │
 │                                              ▼              │
 │                              ┌───────────────────────────┐  │
-│                              │  GitLab CE (service)      │  │
+│                              │  GitLab CE (pre-warmed)   │  │
 │                              │  Ephemeral — fresh state  │  │
 │                              └───────────────────────────┘  │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+## CI Pipeline Overview
+
+Three workflows collaborate:
+
+| Workflow | File | Purpose |
+|----------|------|---------|
+| **Build & Publish** | `build.yml` | Builds MCP + E2E Docker images, validates, pushes to ghcr.io |
+| **E2E Tests** | `e2e.yml` | Boots GitLab CE, runs E2E against the built images |
+| **Warm GitLab** | `warm-gitlab.yml` | Pre-warms GitLab CE image (weekly + on-demand) |
+
+### Trigger chain
+
+```text
+push to main → build.yml (validate + docker) → e2e.yml (auto-triggered via workflow_run)
+```
+
+For branches, add `[e2e]` or `[build]` to the commit message to trigger the chain.
+
+### Tool Coverage Gate
+
+`scripts/check-tool-coverage.sh` runs during the `validate` job in `build.yml`.
+It extracts all MCP tool case statements from `src/index.ts` and verifies each
+tool has at least one call in `e2e/src/tests/`. The build fails immediately if a
+tool is added without test coverage.
+
+Premium-only tools (group wiki) are excluded via a whitelist in the script.
 
 ## What's Tested
 
@@ -37,7 +64,7 @@ every tool against a real, ephemeral GitLab CE instance — no mocks.
 | Branch Protection | `list_protected_branches`, `protect_branch`, `unprotect_branch` | 3 |
 | Environments & Releases | `list_environments`, `list_releases`, `create_release` | 3 |
 
-**Total: ~75 tests covering all 86 tools** (some tools share test cases via roundtrips).
+**Total: 81 tests covering all 86 tools** (some tools share test cases via roundtrips; 5 group wiki tests skipped — Premium only).
 
 ## Prerequisites
 
@@ -79,10 +106,48 @@ npm run teardown
 ## CI Workflow
 
 The E2E tests run automatically via `.github/workflows/e2e.yml`:
-- **Trigger**: Push to `main` (when `e2e/` or `src/` change), PRs, or manual dispatch
-- **GitLab CE**: Runs as a GitHub Actions service container (ephemeral, ~3 min boot)
-- **No shared runners**: Uses free `ubuntu-latest` — no GitLab.com runners needed
-- **Artifacts**: JUnit XML report uploaded for each run
+
+1. **Build & Publish** completes (Docker images for MCP server + E2E runner pushed to ghcr.io)
+2. **E2E Tests** is triggered via `workflow_run`
+3. Gate job decides: main → always, branches → only if commit message contains `[e2e]`
+4. Pulls pre-warmed GitLab image (falls back to cold `gitlab/gitlab-ce:latest`)
+5. Boots GitLab CE (~2 min warm, ~8-12 min cold)
+6. Provisions fixtures via E2E image (`npm run provision`)
+7. Starts MCP server container (streamable-http mode, PAT auth)
+8. Runs all E2E tests via E2E image (`npm test`)
+9. Uploads JUnit XML report as artifact
+
+**No shared runners**: Uses free `ubuntu-latest` — no GitLab.com runners needed.
+
+## Pre-warmed GitLab Image
+
+Cold-booting GitLab CE takes 8-12 minutes (database migrations, service init).
+The `warm-gitlab.yml` workflow solves this:
+
+### How it works
+
+1. Boots a cold `gitlab/gitlab-ce:<version>` container
+2. Waits for full readiness (`/-/readiness` endpoint)
+3. Stops services gracefully (`gitlab-ctl stop`)
+4. `docker commit` → saves the initialized state as a new image
+5. Pushes to `ghcr.io/<repo>/gitlab-ce-warm:latest` + versioned tag
+
+### Result
+
+The warm image has all migrations applied and services pre-configured.
+It boots in **~2 minutes** instead of 8-12. The E2E workflow automatically
+uses it (with fallback to cold image if unavailable).
+
+### Rebuild schedule
+
+- **Automatic**: weekly (Sunday 03:00 UTC)
+- **Manual**: `workflow_dispatch` with optional `gitlab_version` input
+- **When to rebuild**: after bumping the GitLab CE version in docker-compose
+
+### Configuration
+
+The warm image is stored in ghcr.io under the repository's packages:
+`ghcr.io/<owner>/<repo>/gitlab-ce-warm:<version>` and `:latest`.
 
 ## Environment Variables
 
@@ -115,3 +180,22 @@ docker run --rm \
 3. **Fixture-based** — A provisioning script seeds GitLab with deterministic test data. Tests are order-independent within a file.
 4. **Ephemeral GitLab** — Each CI run gets a fresh GitLab CE instance. No state leaks between runs.
 5. **Same toolchain** — Vitest + TypeScript, consistent with the unit test setup.
+6. **Dockerized runner** — E2E tests are packaged as a Docker image so CI never needs to `npm install` — just pull and run.
+7. **Pre-warmed image** — GitLab cold boot is 8-12 min; the warm workflow cuts it to ~2 min. Rebuilt weekly to avoid drift.
+8. **Coverage gate** — A bash script in the validate job ensures no tool can be added without a corresponding E2E test. Zero-dependency check (grep + sort).
+
+## Limitations
+
+- **GitLab Premium features** — Group wiki tools (`create_group_wiki_page`, etc.) require Premium. They are skipped in tests and excluded from the coverage gate.
+- **Async operations** — Some GitLab operations are async (e.g., group deletion). Tests validate the API accepted the request but do not poll for completion.
+- **No runner available** — GitLab CE in CI has no configured runner, so pipeline jobs stay `pending`. Tests that need job output (e.g., `get_job_log`) handle this gracefully.
+- **Rate limiting** — Tests run sequentially (`fileParallelism: false` in vitest) to avoid overwhelming the single-container GitLab instance.
+
+## Adding a New Tool Test
+
+1. Identify the test file by domain (e.g., `issues.e2e.ts` for issue tools)
+2. Add an `it()` block calling the tool via `globalThis.mcpClient.callTool()`
+3. Use `extractText()` or `extractJson()` from `helpers/types.ts` to parse
+4. Assert on the response structure (not just "defined")
+5. Run `./scripts/check-tool-coverage.sh` locally to verify coverage
+6. The coverage gate in CI will also catch missed tools

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -22,6 +22,12 @@ services:
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'http://gitlab.local'
         gitlab_rails['initial_root_password'] = 'E2eTestPassword1!'
+        # Allow /-/readiness and /-/health endpoints from any source so the
+        # host-side wait-for-gitlab.sh script can poll readiness through
+        # the docker port forward (which presents as the docker bridge IP,
+        # not localhost). Default whitelist is loopback-only and produces
+        # silent 404s for external probes.
+        gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0', '::/0']
         prometheus_monitoring['enable'] = false
         registry['enable'] = false
         sidekiq['concurrency'] = 2

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -12,10 +12,15 @@ services:
     ports:
       - "${GITLAB_HOST_PORT:-8080}:80"
     environment:
-      # external_url uses the host-facing port so GitLab-generated URLs
-      # (clone URLs, OAuth callbacks, etc.) match how callers reach it.
+      # external_url uses a nominal hostname (NOT host:port) so nginx
+      # listens on container's port 80 — that's what the port mapping
+      # and healthcheck below expect. Setting external_url to
+      # http://localhost:<port> would force nginx onto that port instead
+      # and break both the mapping and the healthcheck.
+      # The hostname 'gitlab.local' is also what warm-gitlab.yml uses
+      # in CI, keeping local-dev and CI configs aligned.
       GITLAB_OMNIBUS_CONFIG: |
-        external_url 'http://localhost:${GITLAB_HOST_PORT:-8080}'
+        external_url 'http://gitlab.local'
         gitlab_rails['initial_root_password'] = 'E2eTestPassword1!'
         prometheus_monitoring['enable'] = false
         registry['enable'] = false

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -8,7 +8,7 @@
 # ---------------------------------------------------------------------------
 services:
   gitlab:
-    image: gitlab/gitlab-ce:latest
+    image: gitlab/gitlab-ce:18.11.3-ce.0
     ports:
       - "8080:80"
     environment:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------
+# docker-compose for local E2E test development.
+#
+# Usage:
+#   docker compose -f e2e/docker-compose.yml up -d gitlab
+#   # Wait ~3 min for GitLab to boot
+#   cd e2e && npm run provision && npm test
+# ---------------------------------------------------------------------------
+services:
+  gitlab:
+    image: gitlab/gitlab-ce:latest
+    ports:
+      - "8080:80"
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://localhost:8080'
+        gitlab_rails['initial_root_password'] = 'E2eTestPassword1!'
+        prometheus_monitoring['enable'] = false
+        registry['enable'] = false
+        sidekiq['concurrency'] = 2
+        puma['worker_processes'] = 1
+        gitlab_rails['gitlab_shell_ssh_port'] = 2222
+    shm_size: 512m
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:80/-/readiness"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+      start_period: 180s
+
+  mcp-server:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      GITLAB_URL: http://gitlab:80
+      GITLAB_PERSONAL_ACCESS_TOKEN: ${GITLAB_TOKEN:-}
+      PORT: "3000"
+      USE_STREAMABLE_HTTP: "true"
+    depends_on:
+      gitlab:
+        condition: service_healthy
+
+  e2e-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      GITLAB_URL: http://gitlab:80
+      GITLAB_ROOT_PASSWORD: "E2eTestPassword1!"
+      MCP_SERVER_URL: http://mcp-server:3000
+    depends_on:
+      mcp-server:
+        condition: service_started
+      gitlab:
+        condition: service_healthy

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -10,10 +10,12 @@ services:
   gitlab:
     image: gitlab/gitlab-ce:18.11.3-ce.0
     ports:
-      - "8080:80"
+      - "${GITLAB_HOST_PORT:-8080}:80"
     environment:
+      # external_url uses the host-facing port so GitLab-generated URLs
+      # (clone URLs, OAuth callbacks, etc.) match how callers reach it.
       GITLAB_OMNIBUS_CONFIG: |
-        external_url 'http://localhost:8080'
+        external_url 'http://localhost:${GITLAB_HOST_PORT:-8080}'
         gitlab_rails['initial_root_password'] = 'E2eTestPassword1!'
         prometheus_monitoring['enable'] = false
         registry['enable'] = false

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -362,9 +362,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -447,9 +447,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -464,9 +464,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -654,9 +654,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -671,9 +671,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
@@ -705,9 +705,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
@@ -722,9 +722,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
@@ -756,9 +756,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -826,9 +826,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -843,9 +843,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -886,16 +886,16 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -903,16 +903,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -921,13 +921,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -948,9 +948,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -961,13 +961,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -975,14 +975,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -991,9 +991,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1001,13 +1001,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1333,9 +1333,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1346,32 +1346,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escape-html": {
@@ -1474,12 +1474,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
-      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1666,19 +1666,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1716,9 +1703,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.17",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
-      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1767,9 +1754,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2375,9 +2362,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2422,25 +2409,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -2449,21 +2426,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/router": {
@@ -2734,14 +2711,13 @@
       "optional": true
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -2754,17 +2730,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2807,16 +2800,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -2833,7 +2826,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -2885,19 +2878,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2925,12 +2918,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,3043 @@
+{
+  "name": "@yoda.digital/gitlab-mcp-server-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@yoda.digital/gitlab-mcp-server-e2e",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.9.0",
+        "node-fetch": "^3.3.2"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.19",
+        "tsx": "^4.19.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.16"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
+      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.17",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
+      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@yoda.digital/gitlab-mcp-server-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "End-to-end tests for GitLab MCP Server — verifies all tools against a live GitLab instance via MCP protocol",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "provision": "tsx src/scripts/provision-fixtures.ts",
+    "teardown": "tsx src/scripts/teardown-fixtures.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "tsx": "^4.19.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.16"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/e2e/src/helpers/types.ts
+++ b/e2e/src/helpers/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared types for E2E fixtures and helpers.
+ */
+export interface Fixtures {
+  token: string;
+  groupId: number;
+  groupPath: string;
+  projectId: number;
+  projectPath: string;
+  issueIid: number;
+  mergeRequestIid: number;
+  branchName: string;
+  labelName: string;
+  milestoneName: string;
+  wikiPageSlug: string;
+}
+
+/**
+ * MCP tool call result — accepts the union type from callTool().
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ToolResult = any;
+
+/**
+ * Extract text from an MCP tool result.
+ */
+export function extractText(result: ToolResult): string {
+  const r = result as { content: Array<{ type: string; text?: string }> };
+  const item = r.content.find((c) => c.type === 'text');
+  if (!item || !item.text) throw new Error('No text content in tool result');
+  return item.text;
+}
+
+/**
+ * Parse JSON text from an MCP tool result.
+ * Tools may return multiple text items (summary + JSON data).
+ * This finds the last text item that is valid JSON.
+ */
+export function extractJson<T = unknown>(result: ToolResult): T {
+  const r = result as { content: Array<{ type: string; text?: string }> };
+  const textItems = r.content.filter((c) => c.type === 'text' && c.text);
+  // Try from last to first — JSON data is typically the last item
+  for (let i = textItems.length - 1; i >= 0; i--) {
+    try {
+      return JSON.parse(textItems[i].text!) as T;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(`No valid JSON in tool result. Content: ${textItems.map(t => t.text).join(' | ')}`);
+}

--- a/e2e/src/helpers/types.ts
+++ b/e2e/src/helpers/types.ts
@@ -16,17 +16,37 @@ export interface Fixtures {
 }
 
 /**
- * MCP tool call result — accepts the union type from callTool().
+ * MCP tool call result — accepts either SDK variant.
+ *
+ * `callTool()` returns a discriminated union: one variant has `content`
+ * (CallToolResult), the other has `toolResult: unknown` (legacy/streaming).
+ * Helpers assume the content variant and throw if it's missing.
+ *
+ * This shape is loose enough for both variants but more specific than `any`,
+ * which preserves IDE help on `.content[i].type/.text` for callers.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ToolResult = any;
+export type ToolResult = {
+  content?: Array<{
+    type: string;
+    text?: string;
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+};
+
+function assertContent(result: ToolResult): Array<{ type: string; text?: string }> {
+  if (!result.content || !Array.isArray(result.content)) {
+    throw new Error('Tool result has no content array (likely a toolResult-variant response)');
+  }
+  return result.content;
+}
 
 /**
  * Extract text from an MCP tool result.
  */
 export function extractText(result: ToolResult): string {
-  const r = result as { content: Array<{ type: string; text?: string }> };
-  const item = r.content.find((c) => c.type === 'text');
+  const content = assertContent(result);
+  const item = content.find((c) => c.type === 'text');
   if (!item || !item.text) throw new Error('No text content in tool result');
   return item.text;
 }
@@ -37,8 +57,8 @@ export function extractText(result: ToolResult): string {
  * This finds the last text item that is valid JSON.
  */
 export function extractJson<T = unknown>(result: ToolResult): T {
-  const r = result as { content: Array<{ type: string; text?: string }> };
-  const textItems = r.content.filter((c) => c.type === 'text' && c.text);
+  const content = assertContent(result);
+  const textItems = content.filter((c) => c.type === 'text' && c.text);
   // Try from last to first — JSON data is typically the last item
   for (let i = textItems.length - 1; i >= 0; i--) {
     try {

--- a/e2e/src/scripts/provision-fixtures.ts
+++ b/e2e/src/scripts/provision-fixtures.ts
@@ -196,8 +196,12 @@ async function provision(): Promise<Fixtures> {
     wikiPageSlug: wiki.slug,
   };
 
-  // Write fixtures to file (CI mounts /app/fixtures as a volume)
-  const outDir = process.env.FIXTURES_DIR || '/app/fixtures';
+  // Write fixtures to file. Default is ./fixtures relative to cwd so that
+  // `npm run provision` from the e2e/ directory works on the host (writes
+  // e2e/fixtures/). In-container runs (Dockerfile WORKDIR=/app) also resolve
+  // ./fixtures to /app/fixtures, matching the previous behavior. Override
+  // with FIXTURES_DIR for explicit paths.
+  const outDir = process.env.FIXTURES_DIR || './fixtures';
   const outPath = resolve(outDir, 'fixtures.json');
   mkdirSync(dirname(outPath), { recursive: true });
   // lgtm[js/http-to-file-access] — intentional: test fixtures saved for E2E teardown

--- a/e2e/src/scripts/provision-fixtures.ts
+++ b/e2e/src/scripts/provision-fixtures.ts
@@ -9,7 +9,7 @@ import { writeFileSync, mkdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 
 const GITLAB_URL = process.env.GITLAB_URL || 'http://localhost:8080';
-const GITLAB_ROOT_PASSWORD = process.env.GITLAB_ROOT_PASSWORD || '5iveL!fe';
+const GITLAB_ROOT_PASSWORD = process.env.GITLAB_ROOT_PASSWORD || 'E2eTestPassword1!';
 
 interface Fixtures {
   token: string;

--- a/e2e/src/scripts/provision-fixtures.ts
+++ b/e2e/src/scripts/provision-fixtures.ts
@@ -200,6 +200,7 @@ async function provision(): Promise<Fixtures> {
   const outDir = process.env.FIXTURES_DIR || '/app/fixtures';
   const outPath = resolve(outDir, 'fixtures.json');
   mkdirSync(dirname(outPath), { recursive: true });
+  // lgtm[js/http-to-file-access] — intentional: test fixtures saved for E2E teardown
   writeFileSync(outPath, JSON.stringify(fixtures, null, 2));
   console.log(`✅ Fixtures written to ${outPath}`);
 

--- a/e2e/src/scripts/provision-fixtures.ts
+++ b/e2e/src/scripts/provision-fixtures.ts
@@ -1,0 +1,212 @@
+/**
+ * Provision GitLab fixtures for E2E tests.
+ *
+ * Creates: root token, test group, test project, seed data (issues, branches, etc.)
+ * Outputs fixture IDs to a JSON file consumed by tests.
+ */
+import fetch from 'node-fetch';
+import { writeFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+
+const GITLAB_URL = process.env.GITLAB_URL || 'http://localhost:8080';
+const GITLAB_ROOT_PASSWORD = process.env.GITLAB_ROOT_PASSWORD || '5iveL!fe';
+
+interface Fixtures {
+  token: string;
+  groupId: number;
+  groupPath: string;
+  projectId: number;
+  projectPath: string;
+  issueIid: number;
+  mergeRequestIid: number;
+  branchName: string;
+  labelName: string;
+  milestoneName: string;
+  wikiPageSlug: string;
+}
+
+async function gitlabApi(path: string, options: { method?: string; body?: unknown; token?: string } = {}) {
+  const { method = 'GET', body, token } = options;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['PRIVATE-TOKEN'] = token;
+
+  const res = await fetch(`${GITLAB_URL}/api/v4${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitLab API ${method} ${path} failed (${res.status}): ${text}`);
+  }
+  return res.json();
+}
+
+async function createPersonalAccessToken(): Promise<string> {
+  // First, authenticate as root to get a session cookie / OAuth token
+  // For GitLab CE fresh install, use the Personal Access Token API with root credentials
+  const tokenRes = await fetch(`${GITLAB_URL}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'password',
+      username: 'root',
+      password: GITLAB_ROOT_PASSWORD,
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    throw new Error(`OAuth login failed: ${await tokenRes.text()}`);
+  }
+
+  const { access_token } = (await tokenRes.json()) as { access_token: string };
+
+  // Create a PAT via admin endpoint (CE-compatible: /users/:id/personal_access_tokens)
+  const pat = await fetch(`${GITLAB_URL}/api/v4/users/1/personal_access_tokens`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${access_token}`,
+    },
+    body: JSON.stringify({
+      name: 'e2e-test-token',
+      scopes: ['api', 'read_repository', 'write_repository'],
+      expires_at: new Date(Date.now() + 86400000).toISOString().split('T')[0], // +1 day
+    }),
+  });
+
+  if (!pat.ok) {
+    throw new Error(`PAT creation failed: ${await pat.text()}`);
+  }
+
+  const { token } = (await pat.json()) as { token: string };
+  return token;
+}
+
+async function provision(): Promise<Fixtures> {
+  console.log('🔧 Provisioning GitLab fixtures...');
+
+  // 1. Create API token
+  console.log('   Creating personal access token...');
+  const token = await createPersonalAccessToken();
+
+  // 2. Create test group
+  console.log('   Creating test group...');
+  const group = (await gitlabApi('/groups', {
+    method: 'POST',
+    token,
+    body: { name: 'E2E Test Group', path: 'e2e-test-group', visibility: 'private' },
+  })) as { id: number; full_path: string };
+
+  // 3. Create test project
+  console.log('   Creating test project...');
+  const project = (await gitlabApi('/projects', {
+    method: 'POST',
+    token,
+    body: {
+      name: 'e2e-test-project',
+      namespace_id: group.id,
+      initialize_with_readme: true,
+      visibility: 'private',
+      wiki_enabled: true,
+      issues_enabled: true,
+      merge_requests_enabled: true,
+    },
+  })) as { id: number; path_with_namespace: string };
+
+  // 4. Create a branch
+  console.log('   Creating test branch...');
+  const branchName = 'feature/e2e-test';
+  await gitlabApi(`/projects/${project.id}/repository/branches`, {
+    method: 'POST',
+    token,
+    body: { branch: branchName, ref: 'main' },
+  });
+
+  // 5. Create a file on the branch (for MR diff)
+  await gitlabApi(`/projects/${project.id}/repository/files/e2e-test.md`, {
+    method: 'POST',
+    token,
+    body: {
+      branch: branchName,
+      content: '# E2E Test File\n\nThis file was created by the E2E test provisioner.',
+      commit_message: 'test: add e2e test file',
+    },
+  });
+
+  // 6. Create a label
+  console.log('   Creating test label...');
+  const labelName = 'e2e-test';
+  await gitlabApi(`/projects/${project.id}/labels`, {
+    method: 'POST',
+    token,
+    body: { name: labelName, color: '#428BCA' },
+  });
+
+  // 7. Create a milestone
+  console.log('   Creating test milestone...');
+  const milestoneName = 'E2E Sprint 1';
+  await gitlabApi(`/projects/${project.id}/milestones`, {
+    method: 'POST',
+    token,
+    body: { title: milestoneName },
+  });
+
+  // 8. Create an issue
+  console.log('   Creating test issue...');
+  const issue = (await gitlabApi(`/projects/${project.id}/issues`, {
+    method: 'POST',
+    token,
+    body: { title: 'E2E test issue', description: 'Created by E2E provisioner', labels: labelName },
+  })) as { iid: number };
+
+  // 9. Create a merge request
+  console.log('   Creating test merge request...');
+  const mr = (await gitlabApi(`/projects/${project.id}/merge_requests`, {
+    method: 'POST',
+    token,
+    body: {
+      source_branch: branchName,
+      target_branch: 'main',
+      title: 'E2E test merge request',
+      description: 'Created by E2E provisioner',
+    },
+  })) as { iid: number };
+
+  // 10. Create a wiki page
+  console.log('   Creating test wiki page...');
+  const wiki = (await gitlabApi(`/projects/${project.id}/wikis`, {
+    method: 'POST',
+    token,
+    body: { title: 'E2E Test Page', content: '# E2E Wiki\n\nTest content.' },
+  })) as { slug: string };
+
+  const fixtures: Fixtures = {
+    token,
+    groupId: group.id,
+    groupPath: group.full_path,
+    projectId: project.id,
+    projectPath: project.path_with_namespace,
+    issueIid: issue.iid,
+    mergeRequestIid: mr.iid,
+    branchName,
+    labelName,
+    milestoneName,
+    wikiPageSlug: wiki.slug,
+  };
+
+  // Write fixtures to file (CI mounts /app/fixtures as a volume)
+  const outDir = process.env.FIXTURES_DIR || '/app/fixtures';
+  const outPath = resolve(outDir, 'fixtures.json');
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(fixtures, null, 2));
+  console.log(`✅ Fixtures written to ${outPath}`);
+
+  return fixtures;
+}
+
+provision().catch((err) => {
+  console.error('❌ Provisioning failed:', err);
+  process.exit(1);
+});

--- a/e2e/src/scripts/teardown-fixtures.ts
+++ b/e2e/src/scripts/teardown-fixtures.ts
@@ -14,7 +14,8 @@ interface Fixtures {
 }
 
 async function teardown() {
-  const fixturesDir = process.env.FIXTURES_DIR || '/app/fixtures';
+  // See provision-fixtures.ts for rationale on the default path.
+  const fixturesDir = process.env.FIXTURES_DIR || './fixtures';
   const fixturePath = resolve(fixturesDir, 'fixtures.json');
 
   if (!existsSync(fixturePath)) {

--- a/e2e/src/scripts/teardown-fixtures.ts
+++ b/e2e/src/scripts/teardown-fixtures.ts
@@ -1,0 +1,49 @@
+/**
+ * Teardown GitLab fixtures after E2E tests.
+ * Removes the test group (cascades to project, issues, MRs, etc.)
+ */
+import fetch from 'node-fetch';
+import { readFileSync, existsSync, unlinkSync } from 'fs';
+import { resolve } from 'path';
+
+const GITLAB_URL = process.env.GITLAB_URL || 'http://localhost:8080';
+
+interface Fixtures {
+  token: string;
+  groupId: number;
+}
+
+async function teardown() {
+  const fixturesDir = process.env.FIXTURES_DIR || '/app/fixtures';
+  const fixturePath = resolve(fixturesDir, 'fixtures.json');
+
+  if (!existsSync(fixturePath)) {
+    console.log('⚠️  No fixtures.json found — nothing to tear down.');
+    return;
+  }
+
+  const fixtures: Fixtures = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+
+  console.log('🧹 Tearing down GitLab fixtures...');
+
+  // Delete the test group (cascades to project + all data)
+  const res = await fetch(`${GITLAB_URL}/api/v4/groups/${fixtures.groupId}`, {
+    method: 'DELETE',
+    headers: { 'PRIVATE-TOKEN': fixtures.token },
+  });
+
+  if (res.ok || res.status === 404) {
+    console.log('   ✅ Test group deleted');
+  } else {
+    console.error(`   ❌ Group deletion failed (${res.status}): ${await res.text()}`);
+  }
+
+  // Clean up fixtures file
+  unlinkSync(fixturePath);
+  console.log('✅ Teardown complete');
+}
+
+teardown().catch((err) => {
+  console.error('❌ Teardown failed:', err);
+  process.exit(1);
+});

--- a/e2e/src/scripts/teardown-fixtures.ts
+++ b/e2e/src/scripts/teardown-fixtures.ts
@@ -22,6 +22,7 @@ async function teardown() {
     return;
   }
 
+  // lgtm[js/file-access-to-http] — intentional: reading test fixtures token for cleanup
   const fixtures: Fixtures = JSON.parse(readFileSync(fixturePath, 'utf-8'));
 
   console.log('🧹 Tearing down GitLab fixtures...');

--- a/e2e/src/scripts/wait-for-gitlab.sh
+++ b/e2e/src/scripts/wait-for-gitlab.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Wait for GitLab to be fully ready (HTTP 200 on /-/readiness)
+# Timeout: 5 minutes (GitLab CE takes 2-4 min to boot)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+GITLAB_URL="${GITLAB_URL:-http://gitlab:80}"
+TIMEOUT="${GITLAB_READY_TIMEOUT:-300}"
+INTERVAL=5
+
+echo "⏳ Waiting for GitLab at ${GITLAB_URL} (timeout: ${TIMEOUT}s)..."
+
+elapsed=0
+until curl -sf "${GITLAB_URL}/-/readiness" > /dev/null 2>&1; do
+  if [ "$elapsed" -ge "$TIMEOUT" ]; then
+    echo "❌ GitLab did not become ready within ${TIMEOUT}s"
+    exit 1
+  fi
+  sleep "$INTERVAL"
+  elapsed=$((elapsed + INTERVAL))
+  echo "   ...waiting (${elapsed}s elapsed)"
+done
+
+echo "✅ GitLab is ready (took ~${elapsed}s)"

--- a/e2e/src/setup/global-setup.ts
+++ b/e2e/src/setup/global-setup.ts
@@ -1,0 +1,47 @@
+/**
+ * Global setup for E2E tests.
+ *
+ * 1. Provisions GitLab fixtures (group, project, issues, MR, wiki, etc.)
+ * 2. Establishes a shared MCP client connection to the server under test.
+ * 3. Exposes the client and fixture metadata to all tests via globalThis.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { beforeAll, afterAll } from 'vitest';
+import type { Fixtures } from '../helpers/types.js';
+
+const MCP_SERVER_URL = process.env.MCP_SERVER_URL || 'http://localhost:3000';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var mcpClient: Client;
+  // eslint-disable-next-line no-var
+  var fixtures: Fixtures;
+}
+
+beforeAll(async () => {
+  // Load fixtures (provisioned before test run)
+  const fixturesDir = process.env.FIXTURES_DIR || '/app/fixtures';
+  const fixturePath = resolve(fixturesDir, 'fixtures.json');
+  if (!existsSync(fixturePath)) {
+    throw new Error(
+      'fixtures.json not found. Run `npm run provision` or use the CI workflow which provisions automatically.'
+    );
+  }
+  globalThis.fixtures = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+
+  // Connect MCP client via Streamable HTTP
+  const client = new Client({ name: 'e2e-test-client', version: '1.0.0' });
+  const transport = new StreamableHTTPClientTransport(new URL(`${MCP_SERVER_URL}/mcp`));
+  await client.connect(transport);
+
+  globalThis.mcpClient = client;
+}, 60_000);
+
+afterAll(async () => {
+  if (globalThis.mcpClient) {
+    await globalThis.mcpClient.close();
+  }
+});

--- a/e2e/src/setup/global-setup.ts
+++ b/e2e/src/setup/global-setup.ts
@@ -22,8 +22,9 @@ declare global {
 }
 
 beforeAll(async () => {
-  // Load fixtures (provisioned before test run)
-  const fixturesDir = process.env.FIXTURES_DIR || '/app/fixtures';
+  // Load fixtures (provisioned before test run). See provision-fixtures.ts
+  // for default-path rationale: ./fixtures works for both host and container.
+  const fixturesDir = process.env.FIXTURES_DIR || './fixtures';
   const fixturePath = resolve(fixturesDir, 'fixtures.json');
   if (!existsSync(fixturePath)) {
     throw new Error(

--- a/e2e/src/tests/branch-protection.e2e.ts
+++ b/e2e/src/tests/branch-protection.e2e.ts
@@ -1,0 +1,69 @@
+/**
+ * E2E tests — Branch protection tools
+ *
+ * Tools tested:
+ * - list_protected_branches
+ * - protect_branch
+ * - unprotect_branch
+ */
+import { describe, it, expect } from 'vitest';
+import { extractJson, extractText } from '../helpers/types.js';
+
+describe('Branch protection tools', () => {
+  const branchToProtect = 'main';
+
+  it('protect_branch — protects a branch', async () => {
+    // First unprotect in case it was already protected by default
+    try {
+      await globalThis.mcpClient.callTool({
+        name: 'unprotect_branch',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          name: branchToProtect,
+        },
+      });
+    } catch {
+      // Ignore if not protected
+    }
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'protect_branch',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        name: branchToProtect,
+        push_access_level: 40,
+        merge_access_level: 40,
+      },
+    });
+    const data = extractJson<{ name: string }>(result);
+    expect(data.name).toBe(branchToProtect);
+  });
+
+  it('list_protected_branches — returns the protected branch', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_protected_branches',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ name: string }>>(result);
+    expect(data.some((b) => b.name === branchToProtect)).toBe(true);
+  });
+
+  it('unprotect_branch — removes protection', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'unprotect_branch',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        name: branchToProtect,
+      },
+    });
+    expect(extractText(result)).toBeDefined();
+
+    // Verify branch is no longer in protected list
+    const listResult = await globalThis.mcpClient.callTool({
+      name: 'list_protected_branches',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ name: string }>>(listResult);
+    expect(data.some((b) => b.name === branchToProtect)).toBe(false);
+  });
+});

--- a/e2e/src/tests/environments-releases.e2e.ts
+++ b/e2e/src/tests/environments-releases.e2e.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E tests — Environment & Release tools
+ *
+ * Tools tested:
+ * - list_environments
+ * - get_environment
+ * - list_releases
+ * - create_release
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { extractJson } from '../helpers/types.js';
+
+describe('Environment tools', () => {
+  let environmentId: number | undefined;
+
+  beforeAll(async () => {
+    // Create an environment via the GitLab API (deployments endpoint)
+    // We use create_or_update_file to trigger a deployment-like action,
+    // but environments are typically created by CI. Let's just list and test what exists.
+  });
+
+  it('list_environments — returns environments array', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_environments',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ id: number; name: string }>>(result);
+    expect(Array.isArray(data)).toBe(true);
+    if (data.length > 0) {
+      // If environments exist, validate structure
+      expect(data[0].id).toBeGreaterThan(0);
+      expect(data[0].name).toBeDefined();
+      environmentId = data[0].id;
+    }
+  });
+
+  it('get_environment — returns environment details', async () => {
+    if (!environmentId) {
+      // No environment available — skip gracefully
+      return;
+    }
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_environment',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        environment_id: environmentId,
+      },
+    });
+    const data = extractJson<{ id: number; name: string }>(result);
+    expect(data.id).toBe(environmentId);
+    expect(data.name).toBeDefined();
+  });
+});
+
+describe('Release tools', () => {
+  it('create_release — creates a release', async () => {
+    // Ensure a tag exists
+    const tagName = 'e2e-release-v1.0.0';
+    await globalThis.mcpClient.callTool({
+      name: 'create_tag',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        tag_name: tagName,
+        ref: 'main',
+        message: 'E2E release tag',
+      },
+    });
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_release',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        tag_name: tagName,
+        name: 'E2E Release v1.0.0',
+        description: 'Release created by E2E tests',
+      },
+    });
+    const data = extractJson<{ tag_name: string; name: string }>(result);
+    expect(data.tag_name).toBe(tagName);
+    expect(data.name).toBe('E2E Release v1.0.0');
+  });
+
+  it('list_releases — returns the release we just created', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_releases',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ tag_name: string }>>(result);
+    expect(data.some((r) => r.tag_name === 'e2e-release-v1.0.0')).toBe(true);
+  });
+});

--- a/e2e/src/tests/environments-releases.e2e.ts
+++ b/e2e/src/tests/environments-releases.e2e.ts
@@ -7,17 +7,11 @@
  * - list_releases
  * - create_release
  */
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { extractJson } from '../helpers/types.js';
 
 describe('Environment tools', () => {
   let environmentId: number | undefined;
-
-  beforeAll(async () => {
-    // Create an environment via the GitLab API (deployments endpoint)
-    // We use create_or_update_file to trigger a deployment-like action,
-    // but environments are typically created by CI. Let's just list and test what exists.
-  });
 
   it('list_environments — returns environments array', async () => {
     const result = await globalThis.mcpClient.callTool({

--- a/e2e/src/tests/issues.e2e.ts
+++ b/e2e/src/tests/issues.e2e.ts
@@ -1,0 +1,89 @@
+/**
+ * E2E tests — Issue tools
+ *
+ * Tools tested:
+ * - list_issues
+ * - create_issue
+ * - update_issue
+ * - create_issue_note
+ * - list_issue_notes
+ * - list_issue_discussions
+ */
+import { describe, it, expect } from 'vitest';
+import { extractJson } from '../helpers/types.js';
+
+describe('Issue tools', () => {
+  it('list_issues — returns the provisioned issue', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_issues',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ iid: number }>>(result);
+    expect(data.some((i) => i.iid === globalThis.fixtures.issueIid)).toBe(true);
+  });
+
+  it('create_issue — creates a new issue', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_issue',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        title: 'E2E created issue',
+        description: 'Created during E2E test run',
+      },
+    });
+    const data = extractJson<{ iid: number; title: string }>(result);
+    expect(data.iid).toBeGreaterThan(0);
+    expect(data.title).toBe('E2E created issue');
+  });
+
+  it('update_issue — updates title and labels', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'update_issue',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        issue_iid: globalThis.fixtures.issueIid,
+        title: 'E2E test issue — updated',
+        labels: [globalThis.fixtures.labelName],
+      },
+    });
+    const data = extractJson<{ title: string }>(result);
+    expect(data.title).toBe('E2E test issue — updated');
+  });
+
+  it('create_issue_note — adds a comment', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_issue_note',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        issue_iid: globalThis.fixtures.issueIid,
+        body: 'This is an E2E test comment',
+      },
+    });
+    const data = extractJson<{ id: number; body: string }>(result);
+    expect(data.body).toContain('E2E test comment');
+  });
+
+  it('list_issue_notes — returns the comment we just created', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_issue_notes',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        issue_iid: globalThis.fixtures.issueIid,
+      },
+    });
+    const data = extractJson<Array<{ body: string }>>(result);
+    expect(data.some((n) => n.body.includes('E2E test comment'))).toBe(true);
+  });
+
+  it('list_issue_discussions — returns at least one discussion', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_issue_discussions',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        issue_iid: globalThis.fixtures.issueIid,
+      },
+    });
+    const data = extractJson<Array<{ id: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/src/tests/labels-milestones.e2e.ts
+++ b/e2e/src/tests/labels-milestones.e2e.ts
@@ -1,0 +1,107 @@
+/**
+ * E2E tests — Label & Milestone tools
+ *
+ * Tools tested:
+ * - list_labels
+ * - create_label
+ * - update_label
+ * - list_milestones
+ * - create_milestone
+ * - update_milestone
+ */
+import { describe, it, expect } from 'vitest';
+import { extractJson } from '../helpers/types.js';
+
+describe('Label tools', () => {
+  it('list_labels — returns the provisioned label', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_labels',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ name: string }>>(result);
+    expect(data.some((l) => l.name === globalThis.fixtures.labelName)).toBe(true);
+  });
+
+  it('create_label — creates a new label', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_label',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        name: 'e2e-priority-high',
+        color: '#FF0000',
+        description: 'High priority E2E label',
+      },
+    });
+    const data = extractJson<{ name: string; color: string }>(result);
+    expect(data.name).toBe('e2e-priority-high');
+  });
+
+  it('update_label — renames and recolors', async () => {
+    // Get label ID first
+    const listResult = await globalThis.mcpClient.callTool({
+      name: 'list_labels',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const labels = extractJson<Array<{ id: number; name: string }>>(listResult);
+    const label = labels.find((l) => l.name === 'e2e-priority-high');
+    expect(label).toBeDefined();
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'update_label',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        label_id: label!.id,
+        new_name: 'e2e-priority-critical',
+        color: '#FF4500',
+      },
+    });
+    const data = extractJson<{ name: string }>(result);
+    expect(data.name).toBe('e2e-priority-critical');
+  });
+});
+
+describe('Milestone tools', () => {
+  it('list_milestones — returns the provisioned milestone', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_milestones',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ title: string }>>(result);
+    expect(data.some((m) => m.title === globalThis.fixtures.milestoneName)).toBe(true);
+  });
+
+  it('create_milestone — creates a new milestone', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_milestone',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        title: 'E2E Sprint 2',
+        description: 'Second sprint for E2E',
+      },
+    });
+    const data = extractJson<{ title: string }>(result);
+    expect(data.title).toBe('E2E Sprint 2');
+  });
+
+  it('update_milestone — updates description', async () => {
+    // Get milestone ID
+    const listResult = await globalThis.mcpClient.callTool({
+      name: 'list_milestones',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const milestones = extractJson<Array<{ id: number; title: string }>>(listResult);
+    const ms = milestones.find((m) => m.title === globalThis.fixtures.milestoneName);
+    expect(ms).toBeDefined();
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'update_milestone',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        milestone_id: ms!.id,
+        description: 'Updated by E2E test',
+      },
+    });
+    const data = extractJson<{ description: string }>(result);
+    expect(data.description).toBe('Updated by E2E test');
+  });
+});

--- a/e2e/src/tests/members.e2e.ts
+++ b/e2e/src/tests/members.e2e.ts
@@ -1,0 +1,30 @@
+/**
+ * E2E tests — Members tools
+ *
+ * Tools tested:
+ * - list_project_members
+ * - list_group_members
+ */
+import { describe, it, expect } from 'vitest';
+import { extractJson } from '../helpers/types.js';
+
+describe('Members tools', () => {
+  it('list_project_members — returns at least the owner', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_project_members',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ username: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+    expect(data.some((m) => m.username === 'root')).toBe(true);
+  });
+
+  it('list_group_members — returns at least the owner', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_group_members',
+      arguments: { group_id: String(globalThis.fixtures.groupId) },
+    });
+    const data = extractJson<Array<{ username: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/src/tests/merge-requests.e2e.ts
+++ b/e2e/src/tests/merge-requests.e2e.ts
@@ -18,7 +18,7 @@
  * - merge_merge_request
  */
 import { describe, it, expect } from 'vitest';
-import { extractJson, extractText } from '../helpers/types.js';
+import { extractJson } from '../helpers/types.js';
 
 describe('Merge Request tools', () => {
   it('list_merge_requests — returns the provisioned MR', async () => {

--- a/e2e/src/tests/merge-requests.e2e.ts
+++ b/e2e/src/tests/merge-requests.e2e.ts
@@ -1,0 +1,318 @@
+/**
+ * E2E tests — Merge Request tools
+ *
+ * Tools tested:
+ * - list_merge_requests
+ * - create_merge_request
+ * - update_merge_request
+ * - get_merge_request_changes
+ * - get_merge_request_commits
+ * - approve_merge_request
+ * - unapprove_merge_request
+ * - list_merge_request_notes
+ * - create_merge_request_note
+ * - update_merge_request_note
+ * - list_merge_request_discussions
+ * - create_merge_request_discussion
+ * - rebase_merge_request
+ * - merge_merge_request
+ */
+import { describe, it, expect } from 'vitest';
+import { extractJson, extractText } from '../helpers/types.js';
+
+describe('Merge Request tools', () => {
+  it('list_merge_requests — returns the provisioned MR', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_merge_requests',
+      arguments: { project_id: String(globalThis.fixtures.projectId), state: 'opened' },
+    });
+    const data = extractJson<Array<{ iid: number }>>(result);
+    expect(data.some((mr) => mr.iid === globalThis.fixtures.mergeRequestIid)).toBe(true);
+  });
+
+  it('get_merge_request_changes — shows diffs', async () => {
+    // GitLab CE may take a moment to compute MR diffs — retry once if empty
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const result = await globalThis.mcpClient.callTool({
+        name: 'get_merge_request_changes',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          merge_request_iid: globalThis.fixtures.mergeRequestIid,
+        },
+      });
+      const data = extractJson<{ changes: unknown[] }>(result);
+      if (data.changes.length > 0) {
+        expect(data.changes.length).toBeGreaterThan(0);
+        return;
+      }
+      if (attempt === 0) await new Promise((r) => setTimeout(r, 3000));
+    }
+    // If still empty after retry, the MR genuinely has changes from provisioning
+    // but GitLab hasn't indexed them yet — accept gracefully
+  });
+
+  it('get_merge_request_commits — returns at least one commit', async () => {
+    // GitLab CE may take a moment to index MR commits — retry once
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const result = await globalThis.mcpClient.callTool({
+        name: 'get_merge_request_commits',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          merge_request_iid: globalThis.fixtures.mergeRequestIid,
+        },
+      });
+      const data = extractJson<Array<{ id: string }>>(result);
+      if (data.length > 0) {
+        expect(data[0].id).toMatch(/^[0-9a-f]+$/);
+        return;
+      }
+      if (attempt === 0) await new Promise((r) => setTimeout(r, 3000));
+    }
+  });
+
+  it('update_merge_request — updates title', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'update_merge_request',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+        title: 'E2E test merge request — updated',
+      },
+    });
+    const data = extractJson<{ title: string }>(result);
+    expect(data.title).toBe('E2E test merge request — updated');
+  });
+
+  it('create_merge_request_note — adds a comment', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_merge_request_note',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+        body: 'E2E test MR comment',
+      },
+    });
+    const data = extractJson<{ id: number; body: string }>(result);
+    expect(data.body).toContain('E2E test MR comment');
+  });
+
+  it('list_merge_request_notes — returns the comment', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_merge_request_notes',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+      },
+    });
+    const data = extractJson<Array<{ body: string }>>(result);
+    expect(data.some((n) => n.body.includes('E2E test MR comment'))).toBe(true);
+  });
+
+  it('update_merge_request_note — edits the comment', async () => {
+    // First get the note ID
+    const listResult = await globalThis.mcpClient.callTool({
+      name: 'list_merge_request_notes',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+      },
+    });
+    const notes = extractJson<Array<{ id: number; body: string; system: boolean }>>(listResult);
+    const userNote = notes.find((n) => !n.system && n.body.includes('E2E test MR comment'));
+    expect(userNote).toBeDefined();
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'update_merge_request_note',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+        note_id: userNote!.id,
+        body: 'E2E test MR comment — edited',
+      },
+    });
+    const data = extractJson<{ body: string }>(result);
+    expect(data.body).toContain('edited');
+  });
+
+  it('list_merge_request_discussions — returns discussions', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_merge_request_discussions',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+      },
+    });
+    const data = extractJson<Array<{ id: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+  });
+
+  it('create_merge_request_discussion — creates a thread', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_merge_request_discussion',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+        body: 'E2E discussion thread',
+      },
+    });
+    const data = extractJson<{ id: string }>(result);
+    expect(data.id).toBeDefined();
+  });
+
+  it('approve_merge_request + unapprove_merge_request — roundtrip', async () => {
+    const approveResult = await globalThis.mcpClient.callTool({
+      name: 'approve_merge_request',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+      },
+    });
+    // CE returns an object (approval state) — validate it's valid JSON
+    const approveData = extractJson<Record<string, unknown>>(approveResult);
+    expect(approveData).toBeDefined();
+
+    const unapproveResult = await globalThis.mcpClient.callTool({
+      name: 'unapprove_merge_request',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+      },
+    });
+    const unapproveData = extractJson<Record<string, unknown>>(unapproveResult);
+    expect(unapproveData).toBeDefined();
+  });
+
+  it('rebase_merge_request — triggers rebase', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'rebase_merge_request',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        merge_request_iid: globalThis.fixtures.mergeRequestIid,
+      },
+    });
+    const data = extractJson<{ rebase_in_progress: boolean }>(result);
+    expect(typeof data.rebase_in_progress).toBe('boolean');
+  });
+
+  it('create_merge_request — creates a new MR', async () => {
+    // Create a new branch first
+    await globalThis.mcpClient.callTool({
+      name: 'create_branch',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        branch: 'e2e-mr-branch',
+        ref: 'main',
+      },
+    });
+
+    // Add a file to the branch so MR has changes
+    await globalThis.mcpClient.callTool({
+      name: 'create_or_update_file',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        file_path: 'mr-test-file.txt',
+        content: 'MR test content',
+        commit_message: 'test: add file for MR',
+        branch: 'e2e-mr-branch',
+      },
+    });
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_merge_request',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        source_branch: 'e2e-mr-branch',
+        target_branch: 'main',
+        title: 'E2E second merge request',
+      },
+    });
+    const data = extractJson<{ iid: number }>(result);
+    expect(data.iid).toBeGreaterThan(0);
+  });
+
+  it('merge_merge_request — merges the provisioned MR', async () => {
+    // MR may not be mergeable if a pipeline is pending (no .gitlab-ci.yml initially,
+    // but GitLab CE may still block). Try to merge; skip on pipeline-pending error.
+    try {
+      const result = await globalThis.mcpClient.callTool({
+        name: 'merge_merge_request',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          merge_request_iid: globalThis.fixtures.mergeRequestIid,
+        },
+      });
+      const data = extractJson<{ state: string }>(result);
+      expect(data.state).toBe('merged');
+    } catch (err: unknown) {
+      const msg = (err as Error).message || '';
+      if (msg.includes('cannot be merged') || msg.includes('pipeline')) {
+        // Acceptable on CE with active pipelines
+        return;
+      }
+      throw err;
+    }
+  });
+
+  // Auto-merge requires a pipeline running on the MR (merge_when_pipeline_succeeds).
+  // On CE without pipelines configured on the MR branch, these will fail with 405/406.
+  // We test the tool invocation works and handle the expected CE error gracefully.
+  it('set_auto_merge + cancel_auto_merge — validates tool invocation', async () => {
+    // Create a fresh MR for auto-merge testing
+    const branchName = `e2e-auto-merge-${Date.now()}`;
+    await globalThis.mcpClient.callTool({
+      name: 'create_branch',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        branch: branchName,
+        ref: 'main',
+      },
+    });
+    await globalThis.mcpClient.callTool({
+      name: 'create_or_update_file',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        file_path: 'auto-merge-test.txt',
+        content: 'auto merge test',
+        commit_message: 'test: auto merge',
+        branch: branchName,
+      },
+    });
+    const mrResult = await globalThis.mcpClient.callTool({
+      name: 'create_merge_request',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        source_branch: branchName,
+        target_branch: 'main',
+        title: 'E2E auto-merge test MR',
+      },
+    });
+    const mr = extractJson<{ iid: number }>(mrResult);
+
+    try {
+      const result = await globalThis.mcpClient.callTool({
+        name: 'set_auto_merge',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          merge_request_iid: mr.iid,
+        },
+      });
+      // If it succeeds (pipeline is running), validate and cancel
+      const data = extractJson<{ merge_when_pipeline_succeeds?: boolean }>(result);
+      expect(data).toBeDefined();
+
+      // Now cancel
+      const cancelResult = await globalThis.mcpClient.callTool({
+        name: 'cancel_auto_merge',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          merge_request_iid: mr.iid,
+        },
+      });
+      const cancelData = extractJson<Record<string, unknown>>(cancelResult);
+      expect(cancelData).toBeDefined();
+    } catch {
+      // Expected on CE without active pipeline — 405 Method Not Allowed or 406 Not Acceptable
+      // The tool was invoked correctly, GitLab just requires a running pipeline
+    }
+  });
+});

--- a/e2e/src/tests/pipelines.e2e.ts
+++ b/e2e/src/tests/pipelines.e2e.ts
@@ -1,0 +1,288 @@
+/**
+ * E2E tests — Pipeline & Job tools
+ *
+ * Tools tested:
+ * - list_pipelines
+ * - get_pipeline
+ * - trigger_pipeline
+ * - retry_pipeline
+ * - cancel_pipeline
+ * - list_pipeline_jobs
+ * - get_job
+ * - get_job_log
+ * - retry_job
+ * - cancel_job
+ *
+ * Note: Pipeline tests require a .gitlab-ci.yml to exist in the project.
+ * The provision script creates a minimal CI config.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { extractJson, extractText } from '../helpers/types.js';
+
+describe('Pipeline & Job tools', () => {
+  let pipelineId: number;
+  let jobId: number;
+
+  beforeAll(async () => {
+    // Create a CI config with a fast job that also allows retry/cancel testing
+    await globalThis.mcpClient.callTool({
+      name: 'create_or_update_file',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        file_path: '.gitlab-ci.yml',
+        content: [
+          'test_job:',
+          '  script:',
+          '    - echo "E2E pipeline test"',
+          '    - sleep 2',
+          '',
+        ].join('\n'),
+        commit_message: 'ci: add minimal CI config for E2E',
+        branch: 'main',
+      },
+    });
+
+    // Wait for pipeline to auto-trigger
+    await new Promise((r) => setTimeout(r, 5000));
+
+    // Trigger a pipeline explicitly to ensure one exists
+    await globalThis.mcpClient.callTool({
+      name: 'trigger_pipeline',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        ref: 'main',
+      },
+    });
+
+    // Wait for pipeline to be registered
+    await new Promise((r) => setTimeout(r, 2000));
+  });
+
+  it('list_pipelines — returns at least one pipeline', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_pipelines',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ id: number; status: string; ref: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+    expect(data[0].id).toBeGreaterThan(0);
+    expect(data[0].status).toBeDefined();
+    expect(data[0].ref).toBe('main');
+    pipelineId = data[0].id;
+  });
+
+  it('get_pipeline — returns pipeline details', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_pipeline',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        pipeline_id: pipelineId,
+      },
+    });
+    const data = extractJson<{ id: number; ref: string; status: string }>(result);
+    expect(data.id).toBe(pipelineId);
+    expect(data.ref).toBe('main');
+    expect(data.status).toBeDefined();
+  });
+
+  it('list_pipeline_jobs — returns jobs with structure', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_pipeline_jobs',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        pipeline_id: pipelineId,
+      },
+    });
+    const data = extractJson<Array<{ id: number; name: string; status: string; stage: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+    expect(data[0].name).toBe('test_job');
+    expect(data[0].stage).toBeDefined();
+    expect(data[0].status).toBeDefined();
+    jobId = data[0].id;
+  });
+
+  it('get_job — returns job details with pipeline reference', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_job',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        job_id: jobId,
+      },
+    });
+    const data = extractJson<{ id: number; name: string; pipeline: { id: number } }>(result);
+    expect(data.id).toBe(jobId);
+    expect(data.name).toBe('test_job');
+    expect(data.pipeline.id).toBe(pipelineId);
+  });
+
+  it('get_job_log — returns trace output', async () => {
+    // Wait for job to complete (needs time to produce output)
+    await new Promise((r) => setTimeout(r, 8000));
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_job_log',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        job_id: jobId,
+      },
+    });
+    // Job log may be empty if job hasn't started yet (no runner available in CI)
+    try {
+      const text = extractText(result);
+      expect(text.length).toBeGreaterThan(0);
+    } catch {
+      // Job trace not available — acceptable in CI where runner may not execute jobs
+    }
+  });
+
+  it('trigger_pipeline — creates a new pipeline', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'trigger_pipeline',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        ref: 'main',
+      },
+    });
+    const data = extractJson<{ id: number; status: string; ref: string }>(result);
+    expect(data.id).toBeGreaterThan(0);
+    expect(data.ref).toBe('main');
+  });
+
+  it('cancel_pipeline — cancels a pipeline', async () => {
+    // Trigger a new pipeline to cancel
+    const triggerResult = await globalThis.mcpClient.callTool({
+      name: 'trigger_pipeline',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        ref: 'main',
+      },
+    });
+    const { id } = extractJson<{ id: number }>(triggerResult);
+
+    // Wait a moment for pipeline to start processing
+    await new Promise((r) => setTimeout(r, 2000));
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'cancel_pipeline',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        pipeline_id: id,
+      },
+    });
+    // cancel_pipeline returns pipeline — status depends on timing
+    const data = extractJson<{ id: number; status: string }>(result);
+    expect(data.id).toBe(id);
+    // Pipeline may be in any pre-running or post-cancel state
+    expect(['canceled', 'canceling', 'created', 'pending']).toContain(data.status);
+  });
+
+  it('retry_pipeline — retries a completed/canceled pipeline', async () => {
+    // Wait a moment for the canceled pipeline to settle
+    await new Promise((r) => setTimeout(r, 2000));
+
+    // Get a completed or canceled pipeline to retry
+    const listResult = await globalThis.mcpClient.callTool({
+      name: 'list_pipelines',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const pipelines = extractJson<Array<{ id: number; status: string }>>(listResult);
+    const retryable = pipelines.find((p) => ['canceled', 'failed', 'success'].includes(p.status));
+
+    if (!retryable) {
+      // If no retryable pipeline yet, skip gracefully
+      return;
+    }
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'retry_pipeline',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        pipeline_id: retryable.id,
+      },
+    });
+    const data = extractJson<{ id: number; status: string }>(result);
+    expect(data.id).toBeGreaterThan(0);
+    expect(data.status).toBeDefined();
+  });
+
+  it('cancel_job — cancels a running job', async () => {
+    // Trigger a fresh pipeline so we have a running job
+    const triggerResult = await globalThis.mcpClient.callTool({
+      name: 'trigger_pipeline',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        ref: 'main',
+      },
+    });
+    const pipeline = extractJson<{ id: number }>(triggerResult);
+
+    // Wait for job to start
+    await new Promise((r) => setTimeout(r, 2000));
+
+    const jobsResult = await globalThis.mcpClient.callTool({
+      name: 'list_pipeline_jobs',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        pipeline_id: pipeline.id,
+      },
+    });
+    const jobs = extractJson<Array<{ id: number; status: string }>>(jobsResult);
+    const runningJob = jobs.find((j) => ['running', 'pending', 'created'].includes(j.status));
+
+    if (!runningJob) {
+      // Job already finished — can't cancel
+      return;
+    }
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'cancel_job',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        job_id: runningJob.id,
+      },
+    });
+    const data = extractJson<{ id: number; status: string }>(result);
+    expect(data.id).toBe(runningJob.id);
+    expect(['canceled', 'canceling']).toContain(data.status);
+  });
+
+  it('retry_job — retries a failed/canceled job', async () => {
+    // Find a canceled or failed job from previous tests
+    await new Promise((r) => setTimeout(r, 1000));
+
+    const listResult = await globalThis.mcpClient.callTool({
+      name: 'list_pipelines',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const pipelines = extractJson<Array<{ id: number; status: string }>>(listResult);
+
+    // Look for a pipeline with canceled/failed jobs
+    for (const pl of pipelines) {
+      const jobsResult = await globalThis.mcpClient.callTool({
+        name: 'list_pipeline_jobs',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          pipeline_id: pl.id,
+        },
+      });
+      const jobs = extractJson<Array<{ id: number; status: string }>>(jobsResult);
+      const retryableJob = jobs.find((j) => ['canceled', 'failed'].includes(j.status));
+
+      if (retryableJob) {
+        const result = await globalThis.mcpClient.callTool({
+          name: 'retry_job',
+          arguments: {
+            project_id: String(globalThis.fixtures.projectId),
+            job_id: retryableJob.id,
+          },
+        });
+        const data = extractJson<{ id: number; status: string }>(result);
+        expect(data.id).toBeGreaterThan(0);
+        expect(data.status).toBeDefined();
+        return;
+      }
+    }
+
+    // No retryable job found — not a failure, just skip
+  });
+});

--- a/e2e/src/tests/repository.e2e.ts
+++ b/e2e/src/tests/repository.e2e.ts
@@ -1,0 +1,228 @@
+/**
+ * E2E tests — Repository tools
+ *
+ * Tools tested:
+ * - search_repositories
+ * - create_repository
+ * - get_file_contents
+ * - create_or_update_file
+ * - push_files
+ * - get_repository_tree
+ * - list_commits
+ * - list_branches
+ * - create_branch
+ * - delete_branch
+ * - compare_branches
+ * - list_tags
+ * - create_tag
+ * - fork_repository
+ */
+import { describe, it, expect } from 'vitest';
+import { extractJson, extractText } from '../helpers/types.js';
+
+describe('Repository tools', () => {
+  it('search_repositories — finds the test project', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'search_repositories',
+      arguments: { search: 'e2e-test-project' },
+    });
+    const data = extractJson<{ count: number; items: Array<{ path_with_namespace: string }> }>(result);
+    expect(data.items.some((r) => r.path_with_namespace.includes('e2e-test-project'))).toBe(true);
+  });
+
+  it('get_repository_tree — lists files in root', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_repository_tree',
+      arguments: { project_id: String(globalThis.fixtures.projectId), path: '', ref: 'main' },
+    });
+    const data = extractJson<Array<{ name: string }>>(result);
+    expect(data.some((f) => f.name === 'README.md')).toBe(true);
+  });
+
+  it('get_file_contents — reads README.md with content', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_file_contents',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        file_path: 'README.md',
+        ref: 'main',
+      },
+    });
+    const text = extractText(result);
+    expect(text.length).toBeGreaterThan(0);
+    // README should contain project name or markdown content
+    expect(text).toContain('e2e-test-project');
+  });
+
+  it('create_or_update_file — creates a new file', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_or_update_file',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        file_path: 'e2e-created-file.txt',
+        content: 'Hello from E2E tests',
+        commit_message: 'test: create file via E2E',
+        branch: 'main',
+      },
+    });
+    const data = extractJson<{ file_path: string }>(result);
+    expect(data.file_path).toBe('e2e-created-file.txt');
+  });
+
+  it('push_files — pushes multiple files in one commit', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'push_files',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        branch: 'main',
+        commit_message: 'test: push multiple files via E2E',
+        files: [
+          { path: 'multi-a.txt', content: 'File A' },
+          { path: 'multi-b.txt', content: 'File B' },
+        ],
+      },
+    });
+    const text = extractText(result);
+    expect(text).toBeDefined();
+
+    // Verify both files exist in the repo tree
+    const treeResult = await globalThis.mcpClient.callTool({
+      name: 'get_repository_tree',
+      arguments: { project_id: String(globalThis.fixtures.projectId), path: '', ref: 'main' },
+    });
+    const tree = extractJson<Array<{ name: string }>>(treeResult);
+    expect(tree.some((f) => f.name === 'multi-a.txt')).toBe(true);
+    expect(tree.some((f) => f.name === 'multi-b.txt')).toBe(true);
+  });
+
+  it('list_commits — returns commits with expected structure', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_commits',
+      arguments: { project_id: String(globalThis.fixtures.projectId), ref_name: 'main' },
+    });
+    const data = extractJson<Array<{ id: string; title: string; author_name: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+    expect(data[0].id).toMatch(/^[0-9a-f]{40}$/);
+    expect(data[0].title).toBeDefined();
+    expect(data[0].author_name).toBeDefined();
+  });
+
+  it('list_branches — includes main', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_branches',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ name: string }>>(result);
+    expect(data.some((b) => b.name === 'main')).toBe(true);
+  });
+
+  it('create_branch + delete_branch — roundtrip', async () => {
+    const branchName = `e2e-temp-${Date.now()}`;
+
+    const createResult = await globalThis.mcpClient.callTool({
+      name: 'create_branch',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        branch: branchName,
+        ref: 'main',
+      },
+    });
+    const createData = extractJson<{ name: string }>(createResult);
+    expect(createData.name).toBe(branchName);
+
+    const deleteResult = await globalThis.mcpClient.callTool({
+      name: 'delete_branch',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        branch: branchName,
+      },
+    });
+    expect(extractText(deleteResult)).toBeDefined();
+
+    // Verify branch no longer exists
+    const listResult = await globalThis.mcpClient.callTool({
+      name: 'list_branches',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const branches = extractJson<Array<{ name: string }>>(listResult);
+    expect(branches.some((b) => b.name === branchName)).toBe(false);
+  });
+
+  it('compare_branches — shows diff between branches', async () => {
+    // Create a branch with a unique file so we have a guaranteed diff
+    const compareBranch = `e2e-compare-${Date.now()}`;
+    await globalThis.mcpClient.callTool({
+      name: 'create_branch',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        branch: compareBranch,
+        ref: 'main',
+      },
+    });
+    await globalThis.mcpClient.callTool({
+      name: 'create_or_update_file',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        file_path: 'compare-test.txt',
+        content: 'diff content',
+        commit_message: 'test: add file for compare test',
+        branch: compareBranch,
+      },
+    });
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'compare_branches',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        from: 'main',
+        to: compareBranch,
+      },
+    });
+    const data = extractJson<{ diffs: unknown[] }>(result);
+    expect(data.diffs.length).toBeGreaterThan(0);
+  });
+
+  it('create_tag + list_tags — roundtrip', async () => {
+    const tagName = `e2e-v${Date.now()}`;
+    await globalThis.mcpClient.callTool({
+      name: 'create_tag',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        tag_name: tagName,
+        ref: 'main',
+        message: 'E2E test tag',
+      },
+    });
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_tags',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ name: string }>>(result);
+    expect(data.some((t) => t.name === tagName)).toBe(true);
+  });
+
+  it('create_repository — creates a new project', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_repository',
+      arguments: {
+        name: 'e2e-created-repo',
+        visibility: 'private',
+        initialize_with_readme: true,
+      },
+    });
+    const data = extractJson<{ id: number }>(result);
+    expect(data.id).toBeGreaterThan(0);
+  });
+
+  it('fork_repository — forks the test project', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'fork_repository',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+      },
+    });
+    const data = extractJson<{ id: number }>(result);
+    expect(data.id).toBeGreaterThan(0);
+  });
+});

--- a/e2e/src/tests/users-groups.e2e.ts
+++ b/e2e/src/tests/users-groups.e2e.ts
@@ -1,0 +1,159 @@
+/**
+ * E2E tests — Users & Groups tools
+ *
+ * Tools tested:
+ * - get_current_user
+ * - list_users
+ * - get_user
+ * - list_groups
+ * - get_group
+ * - list_group_subgroups
+ * - create_group
+ * - update_group
+ * - delete_group
+ * - list_group_projects
+ * - get_project
+ * - update_project
+ */
+import { describe, it, expect } from 'vitest';
+import { extractJson, extractText } from '../helpers/types.js';
+
+describe('User tools', () => {
+  it('get_current_user — returns root user', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_current_user',
+      arguments: {},
+    });
+    const data = extractJson<{ username: string }>(result);
+    expect(data.username).toBe('root');
+  });
+
+  it('list_users — returns at least one user', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_users',
+      arguments: {},
+    });
+    const data = extractJson<Array<{ id: number }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+  });
+
+  it('get_user — returns root by ID', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_user',
+      arguments: { user_id: 1 },
+    });
+    const data = extractJson<{ username: string }>(result);
+    expect(data.username).toBe('root');
+  });
+});
+
+describe('Group tools', () => {
+  let subgroupId: number;
+
+  it('list_groups — returns the test group', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_groups',
+      arguments: {},
+    });
+    const data = extractJson<Array<{ id: number }>>(result);
+    expect(data.some((g) => g.id === globalThis.fixtures.groupId)).toBe(true);
+  });
+
+  it('get_group — returns group details', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_group',
+      arguments: { group_id: String(globalThis.fixtures.groupId) },
+    });
+    const data = extractJson<{ id: number; full_path: string }>(result);
+    expect(data.id).toBe(globalThis.fixtures.groupId);
+  });
+
+  it('create_group — creates a subgroup', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_group',
+      arguments: {
+        name: 'E2E Subgroup',
+        path: 'e2e-subgroup',
+        parent_id: globalThis.fixtures.groupId,
+        visibility: 'private',
+      },
+    });
+    const data = extractJson<{ id: number }>(result);
+    expect(data.id).toBeGreaterThan(0);
+    subgroupId = data.id;
+  });
+
+  it('list_group_subgroups — returns the subgroup', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_group_subgroups',
+      arguments: { group_id: String(globalThis.fixtures.groupId) },
+    });
+    const data = extractJson<Array<{ id: number }>>(result);
+    expect(data.some((g) => g.id === subgroupId)).toBe(true);
+  });
+
+  it('update_group — updates description', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'update_group',
+      arguments: {
+        group_id: String(subgroupId),
+        description: 'Updated by E2E',
+      },
+    });
+    const data = extractJson<{ description: string }>(result);
+    expect(data.description).toBe('Updated by E2E');
+  });
+
+  it('delete_group — removes the subgroup', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'delete_group',
+      arguments: { group_id: String(subgroupId) },
+    });
+    // GitLab CE schedules deletion asynchronously (can take 60s+).
+    // We only validate the API accepted the request (no error, returns text).
+    const text = extractText(result);
+    expect(text).toBeDefined();
+    expect(text.toLowerCase()).not.toContain('error');
+  });
+
+  it('list_group_projects — returns the test project', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_group_projects',
+      arguments: { group_id: String(globalThis.fixtures.groupId) },
+    });
+    const data = extractJson<{ count: number; items: Array<{ id: number }> }>(result);
+    expect(data.items.some((p) => p.id === globalThis.fixtures.projectId)).toBe(true);
+  });
+});
+
+describe('Project tools', () => {
+  it('get_project — returns project details', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_project',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<{ id: number; name: string }>(result);
+    expect(data.id).toBe(globalThis.fixtures.projectId);
+  });
+
+  it('update_project — updates description', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'update_project',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        description: 'Updated by E2E tests',
+      },
+    });
+    const data = extractJson<{ description: string }>(result);
+    expect(data.description).toBe('Updated by E2E tests');
+  });
+
+  it('get_project_events — returns recent events', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_project_events',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ action_name: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/src/tests/wiki.e2e.ts
+++ b/e2e/src/tests/wiki.e2e.ts
@@ -1,0 +1,176 @@
+/**
+ * E2E tests — Wiki tools
+ *
+ * Tools tested:
+ * - list_project_wiki_pages
+ * - get_project_wiki_page
+ * - create_project_wiki_page
+ * - edit_project_wiki_page
+ * - delete_project_wiki_page
+ * - upload_project_wiki_attachment
+ * - list_group_wiki_pages
+ * - get_group_wiki_page
+ * - create_group_wiki_page
+ * - edit_group_wiki_page
+ * - delete_group_wiki_page
+ * - upload_group_wiki_attachment
+ */
+import { describe, it, expect } from 'vitest';
+import { extractJson, extractText } from '../helpers/types.js';
+
+describe('Project Wiki tools', () => {
+  it('list_project_wiki_pages — returns the provisioned page', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_project_wiki_pages',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const data = extractJson<Array<{ slug: string }>>(result);
+    expect(data.some((p) => p.slug === globalThis.fixtures.wikiPageSlug)).toBe(true);
+  });
+
+  it('get_project_wiki_page — returns content', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_project_wiki_page',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        slug: globalThis.fixtures.wikiPageSlug,
+      },
+    });
+    const data = extractJson<{ content: string }>(result);
+    expect(data.content).toContain('E2E Wiki');
+  });
+
+  it('create_project_wiki_page — creates a new page', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_project_wiki_page',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        title: 'E2E Created Wiki Page',
+        content: '# Created by E2E\n\nTest content.',
+      },
+    });
+    const data = extractJson<{ slug: string }>(result);
+    expect(data.slug).toBeDefined();
+  });
+
+  it('edit_project_wiki_page — updates content', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'edit_project_wiki_page',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        slug: globalThis.fixtures.wikiPageSlug,
+        content: '# E2E Wiki — Updated\n\nEdited by E2E tests.',
+      },
+    });
+    const data = extractJson<{ content: string }>(result);
+    expect(data.content).toContain('Updated');
+  });
+
+  it('delete_project_wiki_page — removes a page', async () => {
+    // Create a page to delete
+    const createResult = await globalThis.mcpClient.callTool({
+      name: 'create_project_wiki_page',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        title: 'Page To Delete',
+        content: 'This will be deleted',
+      },
+    });
+    const { slug } = extractJson<{ slug: string }>(createResult);
+
+    const result = await globalThis.mcpClient.callTool({
+      name: 'delete_project_wiki_page',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        slug,
+      },
+    });
+    expect(extractText(result)).toBeDefined();
+
+    // Verify page no longer exists in list
+    const listResult = await globalThis.mcpClient.callTool({
+      name: 'list_project_wiki_pages',
+      arguments: { project_id: String(globalThis.fixtures.projectId) },
+    });
+    const pages = extractJson<Array<{ slug: string }>>(listResult);
+    expect(pages.some((p) => p.slug === slug)).toBe(false);
+  });
+
+  it('upload_project_wiki_attachment — uploads a file', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'upload_project_wiki_attachment',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        file_path: 'uploads/e2e-test.txt',
+        content: 'E2E attachment content',
+      },
+    });
+    const data = extractJson<{ file_name: string; file_path: string; branch: string; url: string; markdown: string }>(result);
+    expect(data.file_name).toBe('e2e-test.txt');
+    expect(data.file_path).toContain('uploads/');
+    expect(data.branch).toBeDefined();
+    expect(data.url).toContain('uploads/');
+    expect(data.markdown).toContain('e2e-test.txt');
+  });
+});
+
+// Group wikis require GitLab Premium — skip on CE
+describe.skip('Group Wiki tools', () => {
+  it('create_group_wiki_page — creates a group wiki page', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'create_group_wiki_page',
+      arguments: {
+        group_id: String(globalThis.fixtures.groupId),
+        title: 'E2E Group Wiki Page',
+        content: '# Group Wiki\n\nCreated by E2E.',
+      },
+    });
+    const data = extractJson<{ slug: string }>(result);
+    expect(data.slug).toBeDefined();
+  });
+
+  it('list_group_wiki_pages — returns pages', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_group_wiki_pages',
+      arguments: { group_id: String(globalThis.fixtures.groupId) },
+    });
+    const data = extractJson<Array<{ slug: string }>>(result);
+    expect(data.length).toBeGreaterThan(0);
+  });
+
+  it('get_group_wiki_page — returns content', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_group_wiki_page',
+      arguments: {
+        group_id: String(globalThis.fixtures.groupId),
+        slug: 'E2E-Group-Wiki-Page',
+      },
+    });
+    const data = extractJson<{ content: string }>(result);
+    expect(data.content).toContain('Group Wiki');
+  });
+
+  it('edit_group_wiki_page — updates content', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'edit_group_wiki_page',
+      arguments: {
+        group_id: String(globalThis.fixtures.groupId),
+        slug: 'E2E-Group-Wiki-Page',
+        content: '# Group Wiki — Updated\n\nEdited by E2E.',
+      },
+    });
+    const data = extractJson<{ content: string }>(result);
+    expect(data.content).toContain('Updated');
+  });
+
+  it('delete_group_wiki_page — removes the page', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'delete_group_wiki_page',
+      arguments: {
+        group_id: String(globalThis.fixtures.groupId),
+        slug: 'E2E-Group-Wiki-Page',
+      },
+    });
+    expect(extractText(result)).toBeDefined();
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.e2e.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+    fileParallelism: false,
+    setupFiles: ['src/setup/global-setup.ts'],
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './reports/junit.xml',
+    },
+    coverage: {
+      enabled: false,
+    },
+  },
+});

--- a/scripts/check-tool-coverage.sh
+++ b/scripts/check-tool-coverage.sh
@@ -33,8 +33,11 @@ mapfile -t SOURCE_TOOLS < <(
 )
 
 # 2. Extract all tool names called in E2E tests
+#    Match `name: 'foo'` ONLY when it appears within 2 lines after `.callTool(`,
+#    to avoid false positives from unrelated `name:` fields in fixture data
+#    (e.g. release names, branch names, label names) which inflated the count.
 mapfile -t TESTED_TOOLS < <(
-  grep -roh "name: '[^']*'" "$ROOT_DIR/e2e/src/tests/" | sed "s/name: '//;s/'//" | sort -u
+  grep -rA 2 '\.callTool(' "$ROOT_DIR/e2e/src/tests/" | grep -oh "name: '[^']*'" | sed "s/name: '//;s/'//" | sort -u
 )
 
 # 3. Find uncovered tools

--- a/scripts/check-tool-coverage.sh
+++ b/scripts/check-tool-coverage.sh
@@ -29,12 +29,12 @@ EXCLUDED_TOOLS=(
 
 # 1. Extract all tool names from source (case statements in index.ts)
 mapfile -t SOURCE_TOOLS < <(
-  grep -oP 'case "([^"]+)"' "$ROOT_DIR/src/index.ts" | sed 's/case "//;s/"//' | sort -u
+  grep -o 'case "[^"]*"' "$ROOT_DIR/src/index.ts" | sed 's/case "//;s/"//' | sort -u
 )
 
 # 2. Extract all tool names called in E2E tests
 mapfile -t TESTED_TOOLS < <(
-  grep -rohP "name:\s*'([^']+)'" "$ROOT_DIR/e2e/src/tests/" | sed "s/name: '//;s/'//" | sort -u
+  grep -roh "name: '[^']*'" "$ROOT_DIR/e2e/src/tests/" | sed "s/name: '//;s/'//" | sort -u
 )
 
 # 3. Find uncovered tools

--- a/scripts/check-tool-coverage.sh
+++ b/scripts/check-tool-coverage.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Tool Coverage Gate
+#
+# Ensures every MCP tool defined in src/index.ts has at least one E2E test
+# that calls it. Exits non-zero if any tool is uncovered.
+#
+# Usage: ./scripts/check-tool-coverage.sh [--strict]
+#   --strict: also fail on tools only tested via try/catch (weak coverage)
+#
+# Exit codes:
+#   0 = all tools covered
+#   1 = uncovered tools found
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Tools explicitly excluded from coverage requirements (Premium-only features)
+EXCLUDED_TOOLS=(
+  "create_group_wiki_page"
+  "list_group_wiki_pages"
+  "get_group_wiki_page"
+  "edit_group_wiki_page"
+  "delete_group_wiki_page"
+  "upload_group_wiki_attachment"
+)
+
+# 1. Extract all tool names from source (case statements in index.ts)
+mapfile -t SOURCE_TOOLS < <(
+  grep -oP 'case "([^"]+)"' "$ROOT_DIR/src/index.ts" | sed 's/case "//;s/"//' | sort -u
+)
+
+# 2. Extract all tool names called in E2E tests
+mapfile -t TESTED_TOOLS < <(
+  grep -rohP "name:\s*'([^']+)'" "$ROOT_DIR/e2e/src/tests/" | sed "s/name: '//;s/'//" | sort -u
+)
+
+# 3. Find uncovered tools
+UNCOVERED=()
+for tool in "${SOURCE_TOOLS[@]}"; do
+  # Skip excluded tools
+  skip=false
+  for excluded in "${EXCLUDED_TOOLS[@]}"; do
+    if [[ "$tool" == "$excluded" ]]; then
+      skip=true
+      break
+    fi
+  done
+  if [[ "$skip" == "true" ]]; then
+    continue
+  fi
+
+  # Check if tool appears in tested list
+  found=false
+  for tested in "${TESTED_TOOLS[@]}"; do
+    if [[ "$tool" == "$tested" ]]; then
+      found=true
+      break
+    fi
+  done
+
+  if [[ "$found" == "false" ]]; then
+    UNCOVERED+=("$tool")
+  fi
+done
+
+# 4. Report
+echo "══════════════════════════════════════════════════════════"
+echo "  MCP Tool E2E Coverage Report"
+echo "══════════════════════════════════════════════════════════"
+echo ""
+echo "  Source tools:    ${#SOURCE_TOOLS[@]}"
+echo "  Tested tools:    ${#TESTED_TOOLS[@]}"
+echo "  Excluded:        ${#EXCLUDED_TOOLS[@]} (Premium-only)"
+echo "  Uncovered:       ${#UNCOVERED[@]}"
+echo ""
+
+if [[ ${#UNCOVERED[@]} -gt 0 ]]; then
+  echo "❌ UNCOVERED TOOLS (missing E2E tests):"
+  echo ""
+  for tool in "${UNCOVERED[@]}"; do
+    echo "   • $tool"
+  done
+  echo ""
+  echo "  Add E2E tests for these tools or add them to EXCLUDED_TOOLS"
+  echo "  in scripts/check-tool-coverage.sh if they cannot be tested."
+  echo ""
+  echo "══════════════════════════════════════════════════════════"
+  exit 1
+else
+  echo "✅ All tools have E2E coverage!"
+  echo ""
+  echo "══════════════════════════════════════════════════════════"
+  exit 0
+fi

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -7,6 +7,7 @@ import {
   GitLabRepositorySchema,
   GitLabIssueSchema,
   GitLabMergeRequestSchema,
+  MergeRequestApprovalStateSchema,
   GitLabContentSchema,
   GitLabCreateUpdateFileResponseSchema,
   GitLabSearchResponseSchema,
@@ -31,6 +32,7 @@ import {
   type GitLabRepository,
   type GitLabIssue,
   type GitLabMergeRequest,
+  type MergeRequestApprovalState,
   type GitLabContent,
   type GitLabCreateUpdateFileResponse,
   type GitLabSearchResponse,
@@ -1651,7 +1653,7 @@ export class GitLabApi {
     projectId: string,
     mergeRequestIid: number,
     sha?: string
-  ): Promise<GitLabMergeRequest> {
+  ): Promise<MergeRequestApprovalState> {
     const body: Record<string, string> = {};
     if (sha) {
       body.sha = sha;
@@ -1683,7 +1685,7 @@ export class GitLabApi {
       throw new McpError(ErrorCode.InternalError, errorMessage);
     }
 
-    return GitLabMergeRequestSchema.parse(await response.json());
+    return MergeRequestApprovalStateSchema.parse(await response.json());
   }
 
   /**
@@ -1691,13 +1693,13 @@ export class GitLabApi {
    *
    * @param projectId - The ID or URL-encoded path of the project
    * @param mergeRequestIid - The internal ID of the merge request
-   * @returns A promise that resolves to the merge request details
+   * @returns A promise that resolves to the approval state object returned by GitLab
    * @throws Will throw an error if the GitLab API request fails
    */
   async unapproveMergeRequest(
     projectId: string,
     mergeRequestIid: number
-  ): Promise<GitLabMergeRequest> {
+  ): Promise<MergeRequestApprovalState> {
     const response = await fetch(
       `${this.apiUrl}/projects/${encodeURIComponent(projectId)}/merge_requests/${mergeRequestIid}/unapprove`,
       {
@@ -1718,7 +1720,11 @@ export class GitLabApi {
       throw new McpError(ErrorCode.InternalError, errorMessage);
     }
 
-    return GitLabMergeRequestSchema.parse(await response.json());
+    // unapprove returns 204 No Content on success on CE; coerce to empty state object
+    if (response.status === 204) {
+      return {};
+    }
+    return MergeRequestApprovalStateSchema.parse(await response.json());
   }
 
   /**

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 
 // Wiki Page Format
-export const WikiPageFormatEnum = z.enum(['markdown', 'rdoc', 'asciidoc', 'org']);
+// GitLab CE 18.x returns 'plaintext' on wiki pages created via API without
+// explicit format, in addition to the 4 documented values. Keeping the enum
+// loose so the schema parses real-world responses; tools that accept format
+// as input still validate against the 4 canonical values via a tighter input
+// schema where needed.
+export const WikiPageFormatEnum = z.enum(['markdown', 'rdoc', 'asciidoc', 'org', 'plaintext']);
 export type WikiPageFormat = z.infer<typeof WikiPageFormatEnum>;
 
 // GitLab Note
@@ -69,6 +74,8 @@ export const GitLabRepositorySchema = z.object({
   id: z.number(),
   name: z.string(),
   description: z.string().nullable(),
+  path: z.string().optional(),
+  path_with_namespace: z.string().optional(),
   web_url: z.string(),
   default_branch: z.string(),
   visibility: z.enum(['private', 'internal', 'public']),
@@ -82,6 +89,19 @@ export const GitLabRepositorySchema = z.object({
 });
 
 export type GitLabRepository = z.infer<typeof GitLabRepositorySchema>;
+
+// MR approval state — returned by /api/v4/projects/:id/merge_requests/:iid/approve|unapprove.
+// GitLab CE returns a small subset (NOT a full MergeRequest object), so the schema is loose.
+export const MergeRequestApprovalStateSchema = z.object({
+  id: z.number().optional(),
+  iid: z.number().optional(),
+  approvals_required: z.number().optional(),
+  approvals_left: z.number().optional(),
+  approved: z.boolean().optional(),
+  approved_by: z.array(z.unknown()).optional(),
+}).passthrough();
+
+export type MergeRequestApprovalState = z.infer<typeof MergeRequestApprovalStateSchema>;
 
 // GitLab Fork
 export const GitLabForkSchema = GitLabRepositorySchema;


### PR DESCRIPTION
## Summary

Reincarnation of #63 (originally by @ecthelion77, Olivier Gintrand) onto current `main`. The original PR sat for 12+ days while main shipped 0.7.1 (security batch including avatar_url nullable EE fix) and 0.7.2 (wiki/transport contributions from his #62, also reincarnated) plus 5 Dependabot major bumps. Per project policy, the maintainer absorbs the rebase tax rather than push it onto the contributor — this PR carries Olivier's E2E work forward unchanged where possible, with maintainer corrections layered on top.

## What this PR adds

- **E2E test suite** under `e2e/` — 81 tests covering all 86 MCP tools against a real GitLab CE container. 76 pass + 5 Premium-only skipped on a fresh GitLab volume.
- **CI workflows** — `.github/workflows/e2e.yml` (runs the suite after build) and `.github/workflows/warm-gitlab.yml` (weekly pre-warm of GitLab CE image to cut boot time 8-12 min → 2 min).
- **Coverage gate** — `scripts/check-tool-coverage.sh` blocks merges if a new tool ships without an E2E test, wired into `build.yml`.
- **Docs** — new sections in `CONTRIBUTING.md` for local E2E run + the Path B maintainer rebase pattern.

## What differs from #63 (maintainer corrections)

The reincarnation applies 13 maintainer commits on top of Olivier's 5 cherry-picked commits. Grouped by category:

### Docker / infra corrections to the original suite

- `e2e/Dockerfile` pinned to `node:22-alpine` with digest (was unpinned `node:24-alpine` — Node 22 matches our build-and-test runner)
- `e2e/docker-compose.yml`:
  - `gitlab/gitlab-ce` pinned to `18.11.3-ce.0` (was `:latest` — non-reproducible CI)
  - `external_url` set to nominal `'http://gitlab.local'` (was `'http://localhost:8080'` which forced nginx onto port 8080 inside the container, breaking the docker port mapping that assumed nginx on 80 — silent failure in host-loopback mode)
  - `monitoring_whitelist = ['0.0.0.0/0', '::/0']` added so host-side `wait-for-gitlab.sh` can poll `/-/readiness` through the docker bridge
  - `GITLAB_HOST_PORT` env override added for contributors whose host port 8080 is occupied
- `e2e/.dockerignore` added to prevent fixture/secret leakage into the test runner image
- `warm-gitlab.yml` hardened: `docker/login-action` bumped to v4 (aligning with main); `:latest` tag push gated to scheduled runs only (workflow_dispatch with an older version can no longer regress `:latest`); inline comment noting the public-test password baked into the warm image is intentional, not a secret leak

### Code-quality corrections to the original suite

- `e2e/src/helpers/types.ts` — `ToolResult` narrowed from `any` (CLAUDE.md violation) to an optional-content shape + runtime `assertContent` helper. Loose enough to accept the SDK's `CallToolResult | toolResult-variant` discriminated union; tighter than `any`.
- `e2e/src/scripts/{provision,teardown}-fixtures.ts` + `e2e/src/setup/global-setup.ts` — `FIXTURES_DIR` default changed from absolute `/app/fixtures` to relative `./fixtures` so host runs work (was container-only path; host invocations failed with EACCES). `FIXTURES_DIR` env var still works as explicit override.
- `scripts/check-tool-coverage.sh` — regex tightened from `name: '...'` (matched anywhere) to `-A 2` after `.callTool(`. Eliminates 5 false positives that inflated `Tested: 91 > Source: 86` for unrelated fixture strings. Now reports `Tested: 86 = Source: 86`.
- `e2e/package-lock.json` regenerated against current npm registry (npm version claims verified — TS 6.0.3 and Vitest 4.x ARE real, contrary to the original gemini code review).

## Schema fixes (pre-existing bugs on `main` surfaced by this suite)

The reincarnated suite on first run against GitLab CE 18.x exposed three real bugs in `main` source code (not introduced by #63):

1. **`GitLabRepositorySchema` was missing `path_with_namespace` and `path`** — Zod was silently stripping these from every `/projects` response, so any consumer relying on them saw `undefined`. Caught by the `search_repositories` E2E test.
2. **`approveMergeRequest` / `unapproveMergeRequest` parsed responses as full MergeRequest objects** — GitLab CE's `/approve` and `/unapprove` endpoints return a small approval-state object, not a full MR. The tool threw `Invalid arguments: id, iid, ... required` on every successful call. Added a new `MergeRequestApprovalStateSchema` (loose, passthrough-enabled) and handled the 204 No Content return from CE on unapprove.
3. **`WikiPageFormatEnum` was rejecting `'plaintext'`** — GitLab CE 18.x returns `'plaintext'` on wiki pages created via API without an explicit format, in addition to the 4 documented values. Enum extended.

All three were latent bugs that affected real tool callers; the suite did its job and caught them on first contact with a real GitLab instance.

## Local validation evidence

Ran the full suite locally against `gitlab/gitlab-ce:18.11.3-ce.0` on host (port 18080), with the maintainer corrections applied:

```
 Test Files  10 passed (10)
      Tests  76 passed | 5 skipped (81)
   Duration  34.01s
```

Exactly the contract Olivier promised on the original PR. The 5 skipped tests are Premium-only group-wiki tools that CE doesn't support — whitelisted in the coverage gate.

## CI considerations

- `build-and-test` and `Analyze (javascript-typescript)` are required status checks per the ruleset; both run on this PR.
- `e2e.yml` (newly added) will trigger on `workflow_run` after `build.yml` — but it depends on a pre-warmed GitLab image at `ghcr.io/yoda-digital/mcp-gitlab-server/gitlab-ce-warm:latest`. That image doesn't exist yet. **First-run recommendation**: after this PR lands, manually trigger `warm-gitlab.yml` once to seed the image; subsequent E2E runs will use it. The e2e workflow can be added to required-status-checks afterward.

## Known follow-ups (out of scope for this PR, file separately)

- Suite is non-idempotent — re-running `npm test` without `docker compose down -v` causes ~50% failures from 409 Conflict on duplicated POST entities. Tests should use unique entity names per run. Documented in CONTRIBUTING.md.
- `wait-for-gitlab.sh` default timeout is 300s but cold boot is 8-12 min. Bump default to 900s in a follow-up.

## Credit

Original suite design and ~80% of the implementation: @ecthelion77 (Olivier Gintrand). All 5 of his commits cherry-picked with `git cherry-pick -C` so his authorship is preserved on each one; the squash merge to `main` carries a `Co-authored-by:` trailer so the contribution graph reflects his work correctly.

Co-authored-by: Olivier Gintrand <olivier.gintrand@forterro.com>
