### PR TITLE
docs: operational runbooks + release ceremony + CLAUDE.md refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,22 @@ E2E test infrastructure (reincarnation of #63 by @ecthelion77, Olivier Gintrand)
   permissions and `:latest` push gating hardened. Full per-commit detail on the
   reincarnation PR.
 
+### Documentation
+
+- **`docs/OPERATIONS.md`** gained two operational runbooks:
+  "Release atomicity & recovery" (closes #47) covering the independent
+  failure modes of `build.yml` and `publish.yml` plus `gh CLI` recovery
+  commands for each asymmetric case, and "First-publish runbook: ghcr.io
+  package" (closes #51) covering the one-time visibility/Actions-access
+  setup for a freshly created container package on GitHub.
+- **`CONTRIBUTING.md`** gained a "🎯 Release ceremony" section (closes #49)
+  documenting the release-driven publish model (since #43): when to cut a
+  release, the 8-step maintainer procedure, and the anti-patterns (no
+  manual `npm publish`, no amends to published releases, no CHANGELOG
+  rewrites).
+- **`CLAUDE.md`** test note refreshed to mention the new `e2e/` suite +
+  coverage gate, and to list all current unit test files.
+
 ### Credits
 
 - E2E suite design and ~80% of the implementation: @ecthelion77 (Olivier Gintrand).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm start        # Run compiled server
 npm run dev      # Development with ts-node hot reload
 ```
 
-**Note**: `npm test` runs vitest (`vitest run`). Existing specs live alongside source: `src/formatters.test.ts`, `src/schemas.test.ts`, `src/gitlab-api.test.ts`. New behavior (transport, OAuth, /healthz, etc.) should ship with vitest coverage. No dedicated linter is configured; TypeScript strict mode handles type checking.
+**Note**: `npm test` runs vitest (`vitest run`). Unit specs live alongside source: `src/formatters.test.ts`, `src/schemas.test.ts`, `src/gitlab-api.test.ts`, `src/transport.test.ts`, `src/utils.test.ts`. Plus an **E2E suite under `e2e/`** that runs against a real GitLab CE container (81 tests, 86 tools, see `CONTRIBUTING.md` § "Running the E2E suite locally"). The coverage gate in `scripts/check-tool-coverage.sh` (wired into `build.yml`) fails the build if a new tool ships without an E2E test. No dedicated linter is configured; TypeScript strict mode handles type checking.
 
 **Security:** Vulnerabilities go through [GitHub Private Vulnerability Reporting](https://github.com/yoda-digital/mcp-gitlab-server/security/advisories/new) — never via public issues. Threat model and scope are in `SECURITY.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,6 +372,78 @@ The discipline is non-negotiable: a public commit-message promise to a contribut
 
 ---
 
+## 🎯 Release ceremony
+
+This project uses a **release-driven publish model** (since PR #43, released as v0.5.0). Code landing on `main` does **not** publish to npm — releases are deliberate, versioned ceremonies. The `publish.yml` workflow fires on `release.published` or `workflow_dispatch`; pushes to `main` only run `build-and-test` as a safety net.
+
+### When to cut a release
+
+| Trigger | Lead time |
+|---|---|
+| Any user-visible bug fix or feature | Within ~7 days of merge |
+| Security fix (alert closed, CVE patched) | Within 24 hours of merge |
+| Internal refactor with no user-visible change | Can wait for the next batched release |
+| Dependency-only patch bumps (Dependabot) | Batch into the next release; don't ceremonize each bump |
+
+### Cutting a release — maintainer steps
+
+1. **Confirm `main` is green**:
+   ```bash
+   gh run list --branch main --limit 3
+   ```
+
+2. **Bump the version**:
+   ```bash
+   npm version <patch|minor|major> --no-git-tag-version
+   ```
+   This updates `package.json` and `package-lock.json` only — the actual git tag is created via the GitHub Release in step 6.
+
+3. **Date the CHANGELOG**: in `CHANGELOG.md`, move the `## [Unreleased]` entries under a new section `## [X.Y.Z] - YYYY-MM-DD` (use today's UTC date). Leave `[Unreleased]` empty for the next round of entries.
+
+4. **Commit on a release branch**:
+   ```bash
+   git checkout -b release/X.Y.Z
+   git add package.json package-lock.json CHANGELOG.md
+   git commit -m "chore(release): X.Y.Z"
+   git push -u origin release/X.Y.Z
+   ```
+
+5. **Open and merge the release PR**:
+   ```bash
+   gh pr create --title "chore(release): X.Y.Z" --body "Release prep — version bump + CHANGELOG dating."
+   # After CI green:
+   gh pr merge <N> --squash --admin --delete-branch
+   ```
+
+6. **Create the GitHub Release on the merge commit**:
+   ```bash
+   gh release create vX.Y.Z \
+     --title "vX.Y.Z — <one-line summary>" \
+     --notes-file <(awk '/^## \[X\.Y\.Z\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md) \
+     --target main
+   ```
+   The `release.published` event fires immediately and starts `publish.yml`.
+
+7. **Verify the release converged**:
+   - npm: `npm view @yoda.digital/gitlab-mcp-server@X.Y.Z`
+   - ghcr: `docker pull ghcr.io/yoda-digital/mcp-gitlab-server:X.Y.Z`
+   - Helm: confirm via `gh run view <build-run-id>` that the chart push step succeeded.
+
+8. **Update the public portal** at `https://opensource.yoda.digital` (mirrors CHANGELOG entries).
+
+### Recovery
+
+If either leg of the release pipeline fails, see `docs/OPERATIONS.md` → "Release atomicity & recovery". Do **not** delete the GitHub Release or tag — they may be cached downstream.
+
+### What NOT to do
+
+- **Don't `npm publish` from your laptop.** Trusted Publishing is the only authorized path; manual publishes break the audit chain.
+- **Don't amend a published release.** npm versions are immutable; downstream consumers cache them.
+- **Don't skip the version bump** even for tiny fixes. The publish workflow expects monotonic versions and will reject duplicates.
+- **Don't rewrite historical CHANGELOG entries.** The public portal at opensource.yoda.digital mirrors them; rewrites break that mirror.
+
+---
+
 ## 🚫 What NOT to Do
 
 ### ❌ Don't

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -85,3 +85,104 @@ Active sessions are stored in-memory. If session count grows unbounded:
 ### CORS errors in browser console
 
 In OAuth mode, `Access-Control-Allow-Origin: *` is intentionally **not** sent. Set `CORS_ALLOW_ORIGINS` to the exact origin(s) of your frontend application.
+
+## Release atomicity & recovery
+
+The release pipeline has two independent legs that can succeed or fail independently:
+
+- **`build.yml`** — runs on push/tag and publishes the Docker image to `ghcr.io` when a tag is pushed. Helm chart is packaged and pushed on tag pushes as well.
+- **`publish.yml`** — runs only on `release.published` or `workflow_dispatch` and publishes the npm package via OIDC Trusted Publishing.
+
+A successful release means both legs landed: npm has the new version, ghcr has the new image, and (on tag pushes) the Helm chart is in the OCI registry. When one leg fails, the other already-published artifact is **immutable** and must not be rewritten — recovery means re-running the failed leg so the two sides converge.
+
+### Recovery paths
+
+#### npm publish succeeded but Docker push failed
+
+1. Verify npm: `npm view @yoda.digital/gitlab-mcp-server@<version>`
+2. Re-run `Build & Publish` against the tag:
+   ```bash
+   gh run list --workflow=build.yml --branch v<version>
+   gh run rerun <run-id> --failed
+   ```
+3. Verify the image landed:
+   ```bash
+   docker pull ghcr.io/yoda-digital/mcp-gitlab-server:<version>
+   gh api /orgs/yoda-digital/packages/container/mcp-gitlab-server/versions | jq '.[0].metadata.container.tags'
+   ```
+
+#### Docker push succeeded but npm publish failed
+
+1. Verify the ghcr image is live (commands above).
+2. Inspect why `publish-npm` failed:
+   ```bash
+   gh run list --workflow=publish.yml --limit 5
+   gh run view <publish-run-id> --log-failed
+   ```
+   Common cause: Trusted Publishing configuration drift on npmjs.com. Check Package settings → Trusted publishers → verify the workflow filename, environment name, and repository all match. See [`reference_npm_publish_404_trap` lessons in memory] for an instance where a misleading `404 PUT` masked an auth-config issue.
+3. Re-trigger publish via `workflow_dispatch`:
+   ```bash
+   gh workflow run publish.yml --ref v<version>
+   ```
+
+#### Both legs failed
+
+1. Investigate the root cause before re-triggering (GitHub outage, registry incident, dependency failure). Don't blindly re-run if the underlying environment hasn't recovered.
+2. If the tag + release artifacts are still valid, re-trigger both legs as above.
+3. If the tag itself is bad (e.g. `version` in `package.json` doesn't match the tag, or the release was published from the wrong SHA): **do NOT delete the tag or release** — they may be cached downstream. Instead, bump the version, create a new tag, and document the skipped version in CHANGELOG.
+
+### Verifying a full release post-recovery
+
+```bash
+# npm side
+npm view @yoda.digital/gitlab-mcp-server@<version> --json | jq '{version, dist: .dist | {tarball, integrity, signatures}}'
+# .dist.signatures present = Sigstore provenance attached via Trusted Publishing
+
+# Container side
+docker pull ghcr.io/yoda-digital/mcp-gitlab-server:<version>
+docker inspect ghcr.io/yoda-digital/mcp-gitlab-server:<version> --format='{{.Config.Labels}}'
+```
+
+Both should report the expected version. Note recovery actions in `CHANGELOG.md` if the convergence took more than the standard ceremony — operators downstream may need that context when bisecting.
+
+## First-publish runbook: ghcr.io package
+
+When `ghcr.io/yoda-digital/mcp-gitlab-server` is first published, GitHub creates the container package in **private** mode by default and does **not** link it to the source repository. Both need to be fixed manually once per package, after the first successful `build.yml` run that pushes an image.
+
+### One-time setup steps
+
+1. After the first successful build, navigate to:
+   `https://github.com/orgs/yoda-digital/packages/container/mcp-gitlab-server/settings`
+2. Under **Manage Actions access**, add the `mcp-gitlab-server` repository with the **Write** role. This is what lets subsequent CI runs push to this package without an additional OAuth dance.
+3. Under **Danger Zone** → **Change visibility**, set to **Public**. Without this, anonymous `docker pull` returns 403.
+4. Under **Repository**, link the package to `yoda-digital/mcp-gitlab-server` so the README, license, and source link show up on the package landing page.
+
+### Verification
+
+```bash
+# Anonymous pull should succeed
+docker pull ghcr.io/yoda-digital/mcp-gitlab-server:latest
+
+# Package metadata should report visibility + source repo
+gh api /orgs/yoda-digital/packages/container/mcp-gitlab-server \
+  | jq '{visibility, repository: .repository.full_name, html_url: .html_url}'
+```
+
+Expected:
+```json
+{
+  "visibility": "public",
+  "repository": "yoda-digital/mcp-gitlab-server",
+  "html_url": "https://github.com/orgs/yoda-digital/packages/container/package/mcp-gitlab-server"
+}
+```
+
+### Failure mode: "denied" on subsequent CI pushes
+
+If `build.yml` succeeds initially but later runs start failing with `denied: permission_denied` on the push step, the Actions access from step 2 has dropped. This can happen if:
+
+- The repo was renamed or moved.
+- The org's default Actions permissions tightened.
+- A maintainer was removed and the package's per-repo grant was tied to their account.
+
+Fix: re-apply step 2.


### PR DESCRIPTION
## Summary

Docs bundle that closes 3 aging issues (all from 2026-05-04, all docs/CI on the same files) plus a small `CLAUDE.md` refresh post-Phase-E. Zero code changes, no version bump required.

## Changes

### `docs/OPERATIONS.md` — two new operational runbooks

- **"Release atomicity & recovery"** (closes #47) — documents the independent failure modes of `build.yml` (Docker/Helm push) and `publish.yml` (npm via OIDC Trusted Publishing). Concrete `gh` CLI recovery commands for each asymmetric case (npm-succeeded-docker-failed, docker-succeeded-npm-failed, both-failed) plus the verification commands to confirm convergence.
- **"First-publish runbook: ghcr.io package"** (closes #51) — the one-time setup steps after a ghcr container package is created for the first time (Actions access, public visibility, source-repo link), plus the verification command and the failure mode for subsequent `denied: permission_denied` errors on push.

### `CONTRIBUTING.md` — release ceremony section

- **"🎯 Release ceremony"** (closes #49) — documents the release-driven publish model (since #43), the trigger table for when to cut a release, the 8-step maintainer procedure (green main → version bump → CHANGELOG dating → release PR → GitHub Release → verification → portal sync), a pointer to OPERATIONS.md for recovery, and the anti-patterns (no manual `npm publish`, no amends, no version skips, no CHANGELOG rewrites).

### `CLAUDE.md` — test note refresh

- Mentions the `e2e/` suite + coverage gate (landed in PR #81 as part of the same `[Unreleased]` cycle).
- Lists all current unit test files (added `transport.test.ts` and `utils.test.ts` which had been missing from the original list).

### `CHANGELOG.md` — `[Unreleased]` Documentation section

Added under the existing E2E suite entries, crediting the 3 closed issues.

## Why bundled

All 3 issues touch `docs/OPERATIONS.md` and/or `CONTRIBUTING.md`. Three small PRs would have been 3× the review overhead for the same payload.

Closes #47.
Closes #49.
Closes #51.
