### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-E2E test infrastructure (reincarnation of #63 by @ecthelion77, Olivier Gintrand) plus three pre-existing schema bugs the suite surfaced on first run against GitLab CE 18.x.
+_Nothing yet. New entries land here between releases._
+
+## [0.8.0] - 2026-05-18
+
+E2E test infrastructure (reincarnation of #63 by @ecthelion77, Olivier Gintrand) plus three pre-existing schema bugs the suite surfaced on first run against GitLab CE 18.x. Also includes three operational runbooks (release atomicity recovery, ghcr first-publish, release ceremony) that close #47, #49, #51.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Release prep — version bump 0.7.2 → 0.8.0 + CHANGELOG dating. No code changes.

## Headline contents of 0.8.0

- **E2E test suite** under `e2e/` (reincarnation of #63 by @ecthelion77) — 81 tests, 86 tools, 76 pass + 5 Premium-skipped clean.
- **3 pre-existing schema fixes** surfaced by the E2E suite on first run (path_with_namespace, MR approval state, plaintext wiki enum).
- **3 operational runbooks** (release atomicity recovery #47, release ceremony #49, ghcr first-publish #51).
- **CLAUDE.md** test note refreshed to mention E2E suite.

Full CHANGELOG entry at the top of `CHANGELOG.md`. After merge: create GitHub Release for v0.8.0; `publish.yml` fires on `release.published` and ships to npm via OIDC Trusted Publishing.