### PR TITLE
chore(release): 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet. New entries land here between releases._
+
+## [0.8.1] - 2026-05-20
+
+Supply-chain hardening release. Brings `ghcr.io/yoda-digital/mcp-gitlab-server` to enterprise procurement-grade posture (multi-arch, SBOM, SLSA provenance, Sigstore cosign signing, Trivy scanning) and hardens the workflow itself with least-privilege OIDC scoping + SHA-pinned actions. Zero impact on the npm package SDK surface.
+
 ### Added
 
 - **Multi-arch container image** (`linux/amd64,linux/arm64`) — Apple Silicon, AWS Graviton, ARM-based Kubernetes nodes now pull native layers from `ghcr.io/yoda-digital/mcp-gitlab-server` instead of running through QEMU emulation. Closes #52.


### PR DESCRIPTION
Release prep — date CHANGELOG entries from `[Unreleased]` under `## [0.8.1] - 2026-05-20`.

Version bump (`package.json`, `package-lock.json`) already landed in #84 as part of the supply-chain hardening work — this PR is a thin ceremony PR per CONTRIBUTING.md § Release ceremony.

After merge: GitHub Release will be created on the merge commit; `release.published` event fires `publish.yml` (npm via OIDC Trusted Publishing) and `build.yml` tag path (signs + publishes versioned `ghcr.io` image + helm chart push to `oci://ghcr.io/yoda-digital/charts`).