### PR TITLE
fix: return structured JSON in all list-* tool responses

### DIFF
--- a/src/formatters.test.ts
+++ b/src/formatters.test.ts
@@ -11,11 +11,28 @@ import {
   formatMilestonesResponse,
   formatProtectedBranchesResponse,
   formatUsersResponse,
-  formatGroupsResponse
+  formatGroupsResponse,
+  formatIssuesResponse,
+  formatMergeRequestsResponse,
+  formatNotesResponse,
+  formatDiscussionsResponse,
+  formatEventsResponse,
+  formatCommitsResponse,
+  formatMembersResponse,
+  formatWikiPagesResponse,
+  formatWikiPageResponse,
+  formatWikiAttachmentResponse
 } from './formatters.js';
 
+/** Helper: parse the single JSON content item returned by all formatters. */
+function parseResponse(response: { content: Array<{ type: string; text: string }> }) {
+  expect(response.content).toHaveLength(1);
+  expect(response.content[0].type).toBe('text');
+  return JSON.parse(response.content[0].text);
+}
+
 describe('formatPipelinesResponse', () => {
-  it('formats pipelines with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatPipelinesResponse({
       count: 2,
       items: [
@@ -46,18 +63,16 @@ describe('formatPipelinesResponse', () => {
       ]
     });
 
-    expect(response.content).toHaveLength(2);
-    expect(response.content[0].text).toBe('Found 2 pipelines');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items).toHaveLength(2);
-    expect(items[0].sha).toBe('abc123de'); // Truncated to 8 chars
-    expect(items[0].status).toBe('success');
+    const data = parseResponse(response);
+    expect(data.count).toBe(2);
+    expect(data.items).toHaveLength(2);
+    expect(data.items[0].sha).toBe('abc123de'); // Truncated to 8 chars
+    expect(data.items[0].status).toBe('success');
   });
 });
 
 describe('formatJobsResponse', () => {
-  it('formats jobs with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatJobsResponse({
       count: 1,
       items: [
@@ -75,16 +90,15 @@ describe('formatJobsResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 1 jobs');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].name).toBe('build-job');
-    expect(items[0].stage).toBe('build');
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].name).toBe('build-job');
+    expect(data.items[0].stage).toBe('build');
   });
 });
 
 describe('formatEnvironmentsResponse', () => {
-  it('formats environments with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatEnvironmentsResponse({
       count: 2,
       items: [
@@ -103,16 +117,15 @@ describe('formatEnvironmentsResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 2 environments');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].name).toBe('production');
-    expect(items[0].state).toBe('available');
+    const data = parseResponse(response);
+    expect(data.count).toBe(2);
+    expect(data.items[0].name).toBe('production');
+    expect(data.items[0].state).toBe('available');
   });
 });
 
 describe('formatBranchesResponse', () => {
-  it('formats branches with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatBranchesResponse({
       count: 1,
       items: [
@@ -130,16 +143,15 @@ describe('formatBranchesResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 1 branches');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].name).toBe('main');
-    expect(items[0].protected).toBe(true);
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].name).toBe('main');
+    expect(data.items[0].protected).toBe(true);
   });
 });
 
 describe('formatTagsResponse', () => {
-  it('formats tags with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatTagsResponse({
       count: 1,
       items: [
@@ -157,16 +169,15 @@ describe('formatTagsResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 1 tags');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].name).toBe('v1.0.0');
-    expect(items[0].message).toBe('Release version 1.0.0');
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].name).toBe('v1.0.0');
+    expect(data.items[0].message).toBe('Release version 1.0.0');
   });
 });
 
 describe('formatTreeResponse', () => {
-  it('formats tree items with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatTreeResponse({
       count: 3,
       items: [
@@ -176,16 +187,15 @@ describe('formatTreeResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 3 items');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].type).toBe('tree');
-    expect(items[1].type).toBe('blob');
+    const data = parseResponse(response);
+    expect(data.count).toBe(3);
+    expect(data.items[0].type).toBe('tree');
+    expect(data.items[1].type).toBe('blob');
   });
 });
 
 describe('formatReleasesResponse', () => {
-  it('formats releases with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatReleasesResponse({
       count: 1,
       items: [
@@ -198,11 +208,10 @@ describe('formatReleasesResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 1 releases');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].tag_name).toBe('v1.0.0');
-    expect(items[0].name).toBe('Version 1.0.0');
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].tag_name).toBe('v1.0.0');
+    expect(data.items[0].name).toBe('Version 1.0.0');
   });
 
   it('truncates long descriptions', () => {
@@ -219,14 +228,14 @@ describe('formatReleasesResponse', () => {
       ]
     });
 
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].description.length).toBeLessThan(longDescription.length);
-    expect(items[0].description.endsWith('...')).toBe(true);
+    const data = parseResponse(response);
+    expect(data.items[0].description.length).toBeLessThan(longDescription.length);
+    expect(data.items[0].description.endsWith('...')).toBe(true);
   });
 });
 
 describe('formatLabelsResponse', () => {
-  it('formats labels with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatLabelsResponse({
       count: 2,
       items: [
@@ -245,16 +254,15 @@ describe('formatLabelsResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 2 labels');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].name).toBe('bug');
-    expect(items[0].color).toBe('#FF0000');
+    const data = parseResponse(response);
+    expect(data.count).toBe(2);
+    expect(data.items[0].name).toBe('bug');
+    expect(data.items[0].color).toBe('#FF0000');
   });
 });
 
 describe('formatMilestonesResponse', () => {
-  it('formats milestones with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatMilestonesResponse({
       count: 1,
       items: [
@@ -273,16 +281,15 @@ describe('formatMilestonesResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 1 milestones');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].title).toBe('v1.0');
-    expect(items[0].state).toBe('active');
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].title).toBe('v1.0');
+    expect(data.items[0].state).toBe('active');
   });
 });
 
 describe('formatProtectedBranchesResponse', () => {
-  it('formats protected branches with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatProtectedBranchesResponse({
       count: 1,
       items: [
@@ -296,16 +303,15 @@ describe('formatProtectedBranchesResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 1 protected branches');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].name).toBe('main');
-    expect(items[0].push_access_levels).toContain('Maintainers');
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].name).toBe('main');
+    expect(data.items[0].push_access_levels).toContain('Maintainers');
   });
 });
 
 describe('formatUsersResponse', () => {
-  it('formats users with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatUsersResponse({
       count: 1,
       items: [
@@ -320,16 +326,15 @@ describe('formatUsersResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 1 users');
-
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].username).toBe('testuser');
-    expect(items[0].name).toBe('Test User');
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].username).toBe('testuser');
+    expect(data.items[0].name).toBe('Test User');
   });
 });
 
 describe('formatGroupsResponse', () => {
-  it('formats groups with summary', () => {
+  it('returns structured JSON with count and items', () => {
     const response = formatGroupsResponse({
       count: 2,
       items: [
@@ -355,10 +360,101 @@ describe('formatGroupsResponse', () => {
       ]
     });
 
-    expect(response.content[0].text).toBe('Found 2 groups');
+    const data = parseResponse(response);
+    expect(data.count).toBe(2);
+    expect(data.items[0].name).toBe('Group One');
+    expect(data.items[1].parent_id).toBe(1);
+  });
+});
 
-    const items = JSON.parse(response.content[1].text);
-    expect(items[0].name).toBe('Group One');
-    expect(items[1].parent_id).toBe(1);
+describe('formatIssuesResponse', () => {
+  it('returns structured JSON with count and items including all fields', () => {
+    const response = formatIssuesResponse({
+      count: 1,
+      items: [
+        {
+          id: 100,
+          iid: 1,
+          project_id: 42,
+          title: 'Test issue',
+          description: 'A bug description',
+          state: 'opened',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          closed_at: null,
+          labels: ['bug'],
+          author: { id: 1, name: 'Alice', username: 'alice', avatar_url: '', web_url: '' },
+          assignees: [{ id: 2, name: 'Bob', username: 'bob', avatar_url: '', web_url: '' }],
+          web_url: 'https://gitlab.com/issues/1'
+        }
+      ]
+    });
+
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].iid).toBe(1);
+    expect(data.items[0].title).toBe('Test issue');
+    expect(data.items[0].description).toBe('A bug description');
+    expect(data.items[0].state).toBe('opened');
+    expect(data.items[0].labels).toEqual(['bug']);
+    expect(data.items[0].author.username).toBe('alice');
+    expect(data.items[0].assignees[0].username).toBe('bob');
+  });
+});
+
+describe('formatEventsResponse', () => {
+  it('returns structured JSON with count and items', () => {
+    const response = formatEventsResponse({
+      count: 1,
+      items: [
+        {
+          id: 1,
+          action_name: 'pushed to',
+          author: { id: 1, name: 'Alice', username: 'alice', avatar_url: '', web_url: '' },
+          created_at: '2024-01-01T00:00:00Z',
+          target_type: 'MergeRequest',
+          target_title: 'Fix bug'
+        }
+      ]
+    });
+
+    const data = parseResponse(response);
+    expect(data.count).toBe(1);
+    expect(data.items[0].action).toBe('pushed to');
+    expect(data.items[0].author).toBe('Alice');
+  });
+});
+
+describe('formatWikiPageResponse', () => {
+  it('returns single wiki page as structured JSON', () => {
+    const response = formatWikiPageResponse({
+      slug: 'home',
+      title: 'Home',
+      format: 'markdown',
+      content: '# Welcome',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      web_url: 'https://gitlab.com/wiki/home'
+    });
+
+    const data = parseResponse(response);
+    expect(data.title).toBe('Home');
+    expect(data.content).toBe('# Welcome');
+  });
+});
+
+describe('formatWikiAttachmentResponse', () => {
+  it('returns attachment info as structured JSON', () => {
+    const response = formatWikiAttachmentResponse({
+      file_name: 'image.png',
+      file_path: 'uploads/image.png',
+      branch: 'main',
+      link: { url: '/uploads/image.png', markdown: '![image](uploads/image.png)' }
+    });
+
+    const data = parseResponse(response);
+    expect(data.file_name).toBe('image.png');
+    expect(data.url).toBe('/uploads/image.png');
+    expect(data.markdown).toContain('image');
   });
 });

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -24,191 +24,136 @@ import {
 } from './schemas.js';
 
 /**
- * Formats the events response for better readability
- * 
- * @param events - The GitLab events response
- * @returns A formatted response object for the MCP tool
+ * Helper: wraps a JSON-serializable value into a single-item MCP text response.
+ * All formatters use this to ensure the response is always a single structured
+ * JSON content item — compatible with all MCP clients and gateways.
+ */
+function jsonResponse(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+/**
+ * Formats the events response.
  */
 export function formatEventsResponse(events: GitLabEventsResponse) {
-  // Create a summary of the events
-  const summary = `Found ${events.count} events`;
-
-  // Format the events data
-  const formattedEvents = events.items.map(event => ({
-    id: event.id,
-    action: event.action_name,
-    author: event.author.name,
-    created_at: event.created_at,
-    target_type: event.target_type || null,
-    target_title: event.target_title || null,
-    push_data: event.push_data || null
-  }));
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedEvents, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: events.count,
+    items: events.items.map(event => ({
+      id: event.id,
+      action: event.action_name,
+      author: event.author.name,
+      created_at: event.created_at,
+      target_type: event.target_type || null,
+      target_title: event.target_title || null,
+      push_data: event.push_data || null
+    }))
+  });
 }
 
 /**
- * Formats the commits response for better readability
- * 
- * @param commits - The GitLab commits response
- * @returns A formatted response object for the MCP tool
+ * Formats the commits response.
  */
 export function formatCommitsResponse(commits: GitLabCommitsResponse) {
-  // Create a summary of the commits
-  const summary = `Found ${commits.count} commits`;
-
-  // Format the commits data
-  const formattedCommits = commits.items.map(commit => ({
-    id: commit.id,
-    short_id: commit.short_id,
-    title: commit.title,
-    author_name: commit.author_name,
-    author_email: commit.author_email,
-    created_at: commit.created_at,
-    message: commit.message,
-    web_url: commit.web_url,
-    stats: commit.stats
-  }));
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedCommits, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: commits.count,
+    items: commits.items.map(commit => ({
+      id: commit.id,
+      short_id: commit.short_id,
+      title: commit.title,
+      author_name: commit.author_name,
+      author_email: commit.author_email,
+      created_at: commit.created_at,
+      message: commit.message,
+      web_url: commit.web_url,
+      stats: commit.stats
+    }))
+  });
 }
 
 /**
- * Formats the issues response for better readability
- * 
- * @param issues - The GitLab issues response
- * @returns A formatted response object for the MCP tool
+ * Formats the issues response.
  */
 export function formatIssuesResponse(issues: GitLabIssuesResponse) {
-  // Create a summary of the issues
-  const summary = `Found ${issues.count} issues`;
-
-  // Format the issues data
-  const formattedIssues = issues.items.map(issue => ({
-    id: issue.id,
-    iid: issue.iid,
-    title: issue.title,
-    description: issue.description,
-    state: issue.state,
-    created_at: issue.created_at,
-    updated_at: issue.updated_at,
-    closed_at: issue.closed_at,
-    labels: issue.labels,
-    author: {
-      name: issue.author.name,
-      username: issue.author.username
-    },
-    assignees: issue.assignees.map(assignee => ({
-      name: assignee.name,
-      username: assignee.username
-    })),
-    web_url: issue.web_url
-  }));
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedIssues, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: issues.count,
+    items: issues.items.map(issue => ({
+      id: issue.id,
+      iid: issue.iid,
+      title: issue.title,
+      description: issue.description,
+      state: issue.state,
+      created_at: issue.created_at,
+      updated_at: issue.updated_at,
+      closed_at: issue.closed_at,
+      labels: issue.labels,
+      author: {
+        name: issue.author.name,
+        username: issue.author.username
+      },
+      assignees: issue.assignees.map(assignee => ({
+        name: assignee.name,
+        username: assignee.username
+      })),
+      web_url: issue.web_url
+    }))
+  });
 }
 
 /**
- * Formats the merge requests response for better readability
- * 
- * @param mergeRequests - The GitLab merge requests response
- * @returns A formatted response object for the MCP tool
+ * Formats the merge requests response.
  */
 export function formatMergeRequestsResponse(mergeRequests: GitLabMergeRequestsResponse) {
-  // Create a summary of the merge requests
-  const summary = `Found ${mergeRequests.count} merge requests`;
-
-  // Format the merge requests data
-  const formattedMergeRequests = mergeRequests.items.map(mr => ({
-    id: mr.id,
-    iid: mr.iid,
-    title: mr.title,
-    description: mr.description,
-    state: mr.state,
-    merged: mr.merged,
-    created_at: mr.created_at,
-    updated_at: mr.updated_at,
-    merged_at: mr.merged_at,
-    closed_at: mr.closed_at,
-    source_branch: mr.source_branch,
-    target_branch: mr.target_branch,
-    author: {
-      name: mr.author.name,
-      username: mr.author.username
-    },
-    assignees: mr.assignees.map(assignee => ({
-      name: assignee.name,
-      username: assignee.username
-    })),
-    web_url: mr.web_url
-  }));
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedMergeRequests, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: mergeRequests.count,
+    items: mergeRequests.items.map(mr => ({
+      id: mr.id,
+      iid: mr.iid,
+      title: mr.title,
+      description: mr.description,
+      state: mr.state,
+      merged: mr.merged,
+      created_at: mr.created_at,
+      updated_at: mr.updated_at,
+      merged_at: mr.merged_at,
+      closed_at: mr.closed_at,
+      source_branch: mr.source_branch,
+      target_branch: mr.target_branch,
+      author: {
+        name: mr.author.name,
+        username: mr.author.username
+      },
+      assignees: mr.assignees.map(assignee => ({
+        name: assignee.name,
+        username: assignee.username
+      })),
+      web_url: mr.web_url
+    }))
+  });
 }
 
 /**
- * Formats the wiki pages response for better readability
- *
- * @param wikiPages - The GitLab wiki pages response
- * @returns A formatted response object for the MCP tool
+ * Formats the wiki pages response.
  */
 export function formatWikiPagesResponse(wikiPages: GitLabWikiPagesResponse) {
-  // Create a summary of the wiki pages
-  const summary = `Found ${wikiPages.count} wiki pages`;
-
-  // Format the wiki pages data
-  const formattedWikiPages = wikiPages.items.map(page => ({
-    slug: page.slug,
-    title: page.title,
-    format: page.format,
-    content: page.content ? (page.content.length > 100 ? `${page.content.substring(0, 100)}...` : page.content) : null,
-    created_at: page.created_at,
-    updated_at: page.updated_at,
-    web_url: page.web_url
-  }));
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedWikiPages, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: wikiPages.count,
+    items: wikiPages.items.map(page => ({
+      slug: page.slug,
+      title: page.title,
+      format: page.format,
+      content: page.content ? (page.content.length > 100 ? `${page.content.substring(0, 100)}...` : page.content) : null,
+      created_at: page.created_at,
+      updated_at: page.updated_at,
+      web_url: page.web_url
+    }))
+  });
 }
 
 /**
- * Formats a single wiki page for better readability
- *
- * @param wikiPage - The GitLab wiki page
- * @returns A formatted response object for the MCP tool
+ * Formats a single wiki page.
  */
 export function formatWikiPageResponse(wikiPage: GitLabWikiPage) {
-  // Format the wiki page data
-  const formattedWikiPage = {
+  return jsonResponse({
     slug: wikiPage.slug,
     title: wikiPage.title,
     format: wikiPage.format,
@@ -216,125 +161,51 @@ export function formatWikiPageResponse(wikiPage: GitLabWikiPage) {
     created_at: wikiPage.created_at,
     updated_at: wikiPage.updated_at,
     web_url: wikiPage.web_url
-  };
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: `Wiki Page: ${wikiPage.title}` },
-      { type: "text", text: JSON.stringify(formattedWikiPage, null, 2) }
-    ]
-  };
+  });
 }
 
 /**
- * Formats a wiki attachment response for better readability
- *
- * @param attachment - The GitLab wiki attachment
- * @returns A formatted response object for the MCP tool
+ * Formats a wiki attachment response.
  */
 export function formatWikiAttachmentResponse(attachment: GitLabWikiAttachment) {
-  // Recent GitLab returns link.{url,markdown}; older versions return a flat url.
-  // Always emit a non-empty url and a usable markdown snippet so consumers
-  // never see undefined fields.
   const url = attachment.link?.url ?? attachment.url ?? '';
   const markdown = attachment.link?.markdown ?? `![${attachment.file_name}](${url})`;
-  const formattedAttachment = {
+  return jsonResponse({
     file_name: attachment.file_name,
     file_path: attachment.file_path,
     branch: attachment.branch,
     url,
     markdown
-  };
-
-  return {
-    content: [
-      { type: "text", text: `Wiki Attachment: ${attachment.file_name}` },
-      { type: "text", text: JSON.stringify(formattedAttachment, null, 2) }
-    ]
-  };
+  });
 }
 
 /**
- * Formats the members response for better readability
- * 
- * @param members - The GitLab members response
- * @returns A formatted response object for the MCP tool
+ * Formats the members response.
  */
 export function formatMembersResponse(members: GitLabMembersResponse) {
-  // Create a summary of the members
-  const summary = `Found ${members.count} members`;
-
-  // Format the members data
-  const formattedMembers = members.items.map(member => ({
-    id: member.id,
-    username: member.username,
-    name: member.name,
-    state: member.state,
-    avatar_url: member.avatar_url,
-    web_url: member.web_url,
-    access_level: member.access_level,
-    access_level_description: member.access_level_description,
-    expires_at: member.expires_at
-  }));
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedMembers, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: members.count,
+    items: members.items.map(member => ({
+      id: member.id,
+      username: member.username,
+      name: member.name,
+      state: member.state,
+      avatar_url: member.avatar_url,
+      web_url: member.web_url,
+      access_level: member.access_level,
+      access_level_description: member.access_level_description,
+      expires_at: member.expires_at
+    }))
+  });
 }
 
 /**
- * Formats the issue notes response for better readability
- *
- * @param notes - The GitLab notes response
- * @returns A formatted response object for the MCP tool
+ * Formats the issue notes response.
  */
 export function formatNotesResponse(notes: GitLabNotesResponse) {
-  // Create a summary of the notes
-  const summary = `Found ${notes.count} notes`;
-
-  // Format the notes data
-  const formattedNotes = notes.items.map(note => ({
-    id: note.id,
-    body: note.body,
-    author: {
-      name: note.author.name,
-      username: note.author.username
-    },
-    created_at: note.created_at,
-    updated_at: note.updated_at,
-    system: note.system,
-    type: note.type || (note.system ? "system" : "comment")
-  }));
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedNotes, null, 2) }
-    ]
-  };
-}
-
-/**
- * Formats the issue discussions response for better readability
- *
- * @param discussions - The GitLab discussions response
- * @returns A formatted response object for the MCP tool
- */
-export function formatDiscussionsResponse(discussions: GitLabDiscussionsResponse) {
-  // Create a summary of the discussions
-  const summary = `Found ${discussions.count} discussions`;
-
-  // Format the discussions data
-  const formattedDiscussions = discussions.items.map(discussion => ({
-    id: discussion.id,
-    individual_note: discussion.individual_note,
-    notes: discussion.notes.map(note => ({
+  return jsonResponse({
+    count: notes.count,
+    items: notes.items.map(note => ({
       id: note.id,
       body: note.body,
       author: {
@@ -346,321 +217,266 @@ export function formatDiscussionsResponse(discussions: GitLabDiscussionsResponse
       system: note.system,
       type: note.type || (note.system ? "system" : "comment")
     }))
-  }));
-
-  // Return the formatted response
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedDiscussions, null, 2) }
-    ]
-  };
+  });
 }
 
 /**
- * Formats the pipelines response for better readability
+ * Formats the issue discussions response.
+ */
+export function formatDiscussionsResponse(discussions: GitLabDiscussionsResponse) {
+  return jsonResponse({
+    count: discussions.count,
+    items: discussions.items.map(discussion => ({
+      id: discussion.id,
+      individual_note: discussion.individual_note,
+      notes: discussion.notes.map(note => ({
+        id: note.id,
+        body: note.body,
+        author: {
+          name: note.author.name,
+          username: note.author.username
+        },
+        created_at: note.created_at,
+        updated_at: note.updated_at,
+        system: note.system,
+        type: note.type || (note.system ? "system" : "comment")
+      }))
+    }))
+  });
+}
+
+/**
+ * Formats the pipelines response.
  */
 export function formatPipelinesResponse(pipelines: GitLabPipelinesResponse) {
-  const summary = `Found ${pipelines.count} pipelines`;
-
-  const formattedPipelines = pipelines.items.map(pipeline => ({
-    id: pipeline.id,
-    status: pipeline.status,
-    ref: pipeline.ref,
-    sha: pipeline.sha.substring(0, 8),
-    source: pipeline.source,
-    created_at: pipeline.created_at,
-    updated_at: pipeline.updated_at,
-    web_url: pipeline.web_url,
-    duration: pipeline.duration,
-    user: pipeline.user ? { name: pipeline.user.name, username: pipeline.user.username } : null
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedPipelines, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: pipelines.count,
+    items: pipelines.items.map(pipeline => ({
+      id: pipeline.id,
+      status: pipeline.status,
+      ref: pipeline.ref,
+      sha: pipeline.sha.substring(0, 8),
+      source: pipeline.source,
+      created_at: pipeline.created_at,
+      updated_at: pipeline.updated_at,
+      web_url: pipeline.web_url,
+      duration: pipeline.duration,
+      user: pipeline.user ? { name: pipeline.user.name, username: pipeline.user.username } : null
+    }))
+  });
 }
 
 /**
- * Formats the jobs response for better readability
+ * Formats the jobs response.
  */
 export function formatJobsResponse(jobs: GitLabJobsResponse) {
-  const summary = `Found ${jobs.count} jobs`;
-
-  const formattedJobs = jobs.items.map(job => ({
-    id: job.id,
-    name: job.name,
-    stage: job.stage,
-    status: job.status,
-    ref: job.ref,
-    created_at: job.created_at,
-    started_at: job.started_at,
-    finished_at: job.finished_at,
-    duration: job.duration,
-    web_url: job.web_url,
-    allow_failure: job.allow_failure,
-    failure_reason: job.failure_reason
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedJobs, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: jobs.count,
+    items: jobs.items.map(job => ({
+      id: job.id,
+      name: job.name,
+      stage: job.stage,
+      status: job.status,
+      ref: job.ref,
+      created_at: job.created_at,
+      started_at: job.started_at,
+      finished_at: job.finished_at,
+      duration: job.duration,
+      web_url: job.web_url,
+      allow_failure: job.allow_failure,
+      failure_reason: job.failure_reason
+    }))
+  });
 }
 
 /**
- * Formats the environments response for better readability
+ * Formats the environments response.
  */
 export function formatEnvironmentsResponse(environments: GitLabEnvironmentsResponse) {
-  const summary = `Found ${environments.count} environments`;
-
-  const formattedEnvironments = environments.items.map(env => ({
-    id: env.id,
-    name: env.name,
-    slug: env.slug,
-    state: env.state,
-    external_url: env.external_url,
-    tier: env.tier,
-    last_deployment: env.last_deployment ? {
-      id: env.last_deployment.id,
-      ref: env.last_deployment.ref,
-      status: env.last_deployment.status,
-      created_at: env.last_deployment.created_at
-    } : null
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedEnvironments, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: environments.count,
+    items: environments.items.map(env => ({
+      id: env.id,
+      name: env.name,
+      slug: env.slug,
+      state: env.state,
+      external_url: env.external_url,
+      tier: env.tier,
+      last_deployment: env.last_deployment ? {
+        id: env.last_deployment.id,
+        ref: env.last_deployment.ref,
+        status: env.last_deployment.status,
+        created_at: env.last_deployment.created_at
+      } : null
+    }))
+  });
 }
 
 /**
- * Formats the branches response for better readability
+ * Formats the branches response.
  */
 export function formatBranchesResponse(branches: GitLabBranchesResponse) {
-  const summary = `Found ${branches.count} branches`;
-
-  const formattedBranches = branches.items.map(branch => ({
-    name: branch.name,
-    protected: branch.protected,
-    default: branch.default,
-    merged: branch.merged,
-    commit: {
-      id: branch.commit.short_id,
-      title: branch.commit.title,
-      created_at: branch.commit.created_at,
-      author_name: branch.commit.author_name
-    },
-    web_url: branch.web_url
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedBranches, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: branches.count,
+    items: branches.items.map(branch => ({
+      name: branch.name,
+      protected: branch.protected,
+      default: branch.default,
+      merged: branch.merged,
+      commit: {
+        id: branch.commit.short_id,
+        title: branch.commit.title,
+        created_at: branch.commit.created_at,
+        author_name: branch.commit.author_name
+      },
+      web_url: branch.web_url
+    }))
+  });
 }
 
 /**
- * Formats the tags response for better readability
+ * Formats the tags response.
  */
 export function formatTagsResponse(tags: GitLabTagsResponse) {
-  const summary = `Found ${tags.count} tags`;
-
-  const formattedTags = tags.items.map(tag => ({
-    name: tag.name,
-    message: tag.message,
-    protected: tag.protected,
-    commit: tag.commit ? {
-      id: tag.commit.short_id,
-      title: tag.commit.title,
-      created_at: tag.commit.created_at
-    } : null,
-    release: tag.release
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedTags, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: tags.count,
+    items: tags.items.map(tag => ({
+      name: tag.name,
+      message: tag.message,
+      protected: tag.protected,
+      commit: tag.commit ? {
+        id: tag.commit.short_id,
+        title: tag.commit.title,
+        created_at: tag.commit.created_at
+      } : null,
+      release: tag.release
+    }))
+  });
 }
 
 /**
- * Formats the repository tree response for better readability
+ * Formats the repository tree response.
  */
 export function formatTreeResponse(tree: GitLabTreeResponse) {
-  const summary = `Found ${tree.count} items`;
-
-  const formattedTree = tree.items.map(item => ({
-    id: item.id,
-    name: item.name,
-    type: item.type,
-    path: item.path,
-    mode: item.mode
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedTree, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: tree.count,
+    items: tree.items.map(item => ({
+      id: item.id,
+      name: item.name,
+      type: item.type,
+      path: item.path,
+      mode: item.mode
+    }))
+  });
 }
 
 /**
- * Formats the releases response for better readability
+ * Formats the releases response.
  */
 export function formatReleasesResponse(releases: GitLabReleasesResponse) {
-  const summary = `Found ${releases.count} releases`;
-
-  const formattedReleases = releases.items.map(release => ({
-    tag_name: release.tag_name,
-    name: release.name,
-    description: release.description ? (release.description.length > 100 ? `${release.description.substring(0, 100)}...` : release.description) : null,
-    created_at: release.created_at,
-    released_at: release.released_at,
-    author: release.author ? { name: release.author.name, username: release.author.username } : null,
-    assets: release.assets ? { count: release.assets.count } : null
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedReleases, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: releases.count,
+    items: releases.items.map(release => ({
+      tag_name: release.tag_name,
+      name: release.name,
+      description: release.description ? (release.description.length > 100 ? `${release.description.substring(0, 100)}...` : release.description) : null,
+      created_at: release.created_at,
+      released_at: release.released_at,
+      author: release.author ? { name: release.author.name, username: release.author.username } : null,
+      assets: release.assets ? { count: release.assets.count } : null
+    }))
+  });
 }
 
 /**
- * Formats the labels response for better readability
+ * Formats the labels response.
  */
 export function formatLabelsResponse(labels: GitLabLabelsResponse) {
-  const summary = `Found ${labels.count} labels`;
-
-  const formattedLabels = labels.items.map(label => ({
-    id: label.id,
-    name: label.name,
-    color: label.color,
-    description: label.description,
-    open_issues_count: label.open_issues_count,
-    open_merge_requests_count: label.open_merge_requests_count,
-    priority: label.priority
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedLabels, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: labels.count,
+    items: labels.items.map(label => ({
+      id: label.id,
+      name: label.name,
+      color: label.color,
+      description: label.description,
+      open_issues_count: label.open_issues_count,
+      open_merge_requests_count: label.open_merge_requests_count,
+      priority: label.priority
+    }))
+  });
 }
 
 /**
- * Formats the milestones response for better readability
+ * Formats the milestones response.
  */
 export function formatMilestonesResponse(milestones: GitLabMilestonesResponse) {
-  const summary = `Found ${milestones.count} milestones`;
-
-  const formattedMilestones = milestones.items.map(milestone => ({
-    id: milestone.id,
-    iid: milestone.iid,
-    title: milestone.title,
-    description: milestone.description,
-    state: milestone.state,
-    due_date: milestone.due_date,
-    start_date: milestone.start_date,
-    expired: milestone.expired,
-    web_url: milestone.web_url
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedMilestones, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: milestones.count,
+    items: milestones.items.map(milestone => ({
+      id: milestone.id,
+      iid: milestone.iid,
+      title: milestone.title,
+      description: milestone.description,
+      state: milestone.state,
+      due_date: milestone.due_date,
+      start_date: milestone.start_date,
+      expired: milestone.expired,
+      web_url: milestone.web_url
+    }))
+  });
 }
 
 /**
- * Formats the protected branches response for better readability
+ * Formats the protected branches response.
  */
 export function formatProtectedBranchesResponse(branches: GitLabProtectedBranchesResponse) {
-  const summary = `Found ${branches.count} protected branches`;
-
-  const formattedBranches = branches.items.map(branch => ({
-    id: branch.id,
-    name: branch.name,
-    push_access_levels: branch.push_access_levels?.map(l => l.access_level_description),
-    merge_access_levels: branch.merge_access_levels?.map(l => l.access_level_description),
-    allow_force_push: branch.allow_force_push,
-    code_owner_approval_required: branch.code_owner_approval_required
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedBranches, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: branches.count,
+    items: branches.items.map(branch => ({
+      id: branch.id,
+      name: branch.name,
+      push_access_levels: branch.push_access_levels?.map(l => l.access_level_description),
+      merge_access_levels: branch.merge_access_levels?.map(l => l.access_level_description),
+      allow_force_push: branch.allow_force_push,
+      code_owner_approval_required: branch.code_owner_approval_required
+    }))
+  });
 }
 
 /**
- * Formats the users response for better readability
+ * Formats the users response.
  */
 export function formatUsersResponse(users: GitLabUsersResponse) {
-  const summary = `Found ${users.count} users`;
-
-  const formattedUsers = users.items.map(user => ({
-    id: user.id,
-    username: user.username,
-    name: user.name,
-    state: user.state,
-    avatar_url: user.avatar_url,
-    web_url: user.web_url,
-    email: user.email,
-    is_admin: user.is_admin
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedUsers, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: users.count,
+    items: users.items.map(user => ({
+      id: user.id,
+      username: user.username,
+      name: user.name,
+      state: user.state,
+      avatar_url: user.avatar_url,
+      web_url: user.web_url,
+      email: user.email,
+      is_admin: user.is_admin
+    }))
+  });
 }
 
 /**
- * Formats the groups response for better readability
+ * Formats the groups response.
  */
 export function formatGroupsResponse(groups: GitLabGroupsResponse) {
-  const summary = `Found ${groups.count} groups`;
-
-  const formattedGroups = groups.items.map(group => ({
-    id: group.id,
-    name: group.name,
-    path: group.path,
-    full_path: group.full_path,
-    description: group.description,
-    visibility: group.visibility,
-    parent_id: group.parent_id,
-    web_url: group.web_url
-  }));
-
-  return {
-    content: [
-      { type: "text", text: summary },
-      { type: "text", text: JSON.stringify(formattedGroups, null, 2) }
-    ]
-  };
+  return jsonResponse({
+    count: groups.count,
+    items: groups.items.map(group => ({
+      id: group.id,
+      name: group.name,
+      path: group.path,
+      full_path: group.full_path,
+      description: group.description,
+      visibility: group.visibility,
+      parent_id: group.parent_id,
+      web_url: group.web_url
+    }))
+  });
 }


### PR DESCRIPTION
## Problem

All `list-*` tools (issues, merge requests, notes, discussions, pipelines, jobs, etc.) return their response as **two separate MCP content items**:
1. A summary string: `"Found N items"`
2. A JSON array of formatted items

MCP clients/gateways that only read the first content item (which is common — e.g. ContextForge, some Copilot integrations) receive **zero useful data** — just a count string.

Meanwhile, `search_repositories` already returns a single content item with `{ count, items }` and works correctly everywhere.

## Fix

Unify all 20 formatters to return a **single structured JSON content item**: `{ count, items: [...] }`.

### Changes

- **`src/formatters.ts`**: extracted shared `jsonResponse()` helper, all formatters now return one content item with `{ count, items }` (or a single object for entity responses like `formatWikiPageResponse`)
- **`src/formatters.test.ts`**: updated all tests for new format, added coverage for `formatIssuesResponse`, `formatEventsResponse`, `formatWikiPageResponse`, `formatWikiAttachmentResponse`
- 90 unit tests pass, zero type errors

### Before/After

**Before** (broken for single-item clients):
```json
{
  "content": [
    { "type": "text", "text": "Found 1 issues" },
    { "type": "text", "text": "[{\"id\": 100, ...}]" }
  ]
}
```

**After** (consistent with `search_repositories`):
```json
{
  "content": [
    { "type": "text", "text": "{\"count\": 1, \"items\": [{\"id\": 100, ...}]}" }
  ]
}
```

Fixes #95