### PR TITLE
fix(chart): allow 'enabled' and 'global' in values schema

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -66,10 +66,12 @@ ingress controller with cookie-based routing). See
 | config.CORS_ALLOW_ORIGINS | string | `""` | Comma-separated list of allowed CORS origins. In PAT-loopback mode: defaults to "*" if empty (local dev only). In OAuth mode: no default (deny browser cross-origin access). |
 | config.HEALTHZ_MAX_SESSIONS | string | `"10000"` | Max sessions before /healthz returns 503 (default 10000) |
 | config.HOST | string | `"0.0.0.0"` | Bind address. Pods must bind to all interfaces for the Service to reach them, so the chart sets HOST=0.0.0.0. Combined with AUTH_MODE=oauth below, network exposure is auth-gated. The application's own default is HOST=127.0.0.1 (loopback) for non-Helm local-dev safety. |
+| enabled | bool | `true` | Sub-chart support: Helm sets this automatically when used as a dependency |
 | existingSecret | string | `""` | Use an existing Secret instead of creating one. The Secret must contain the keys listed in secret{} above. |
 | extraEnv | list | `[]` | Extra env vars (list of {name, value} or {name, valueFrom}) |
 | extraEnvFrom | list | `[]` | Extra envFrom (list of secretRef/configMapRef) |
 | fullnameOverride | string | `""` |  |
+| global | object | `{}` | Sub-chart support: parent chart globals are passed here by Helm |
 | image.digest | string | `""` | Image digest (sha256:...). When set, takes precedence over tag. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/yoda-digital/mcp-gitlab-server"` |  |

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3,6 +3,15 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "enabled": {
+      "type": "boolean",
+      "description": "Enable or disable this subchart when used as a dependency."
+    },
+    "global": {
+      "type": "object",
+      "description": "Global values inherited from parent chart. Not used locally.",
+      "additionalProperties": true
+    },
     "replicaCount": {
       "type": "integer",
       "minimum": 1,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,11 @@
 replicaCount: 1
 
+# -- Sub-chart support: Helm sets this automatically when used as a dependency
+enabled: true
+
+# -- Sub-chart support: parent chart globals are passed here by Helm
+global: {}
+
 # ===========================================================================
 # Fail-loud guards
 # ===========================================================================


### PR DESCRIPTION
## Problem

When `gitlab-mcp` is used as a sub-chart dependency in an umbrella chart, Helm injects two additional top-level properties into the sub-chart's values:

- `enabled` — from the `condition:` field in the parent's `Chart.yaml`
- `global` — inherited global values from the parent chart

Since `values.schema.json` has `"additionalProperties": false` at the root level, `helm template` fails with:

```
at '': additional properties 'enabled', 'global' not allowed
```

This blocks any ArgoCD or Flux deployment using this chart as a dependency.

## Fix

Add both properties to the schema's root `properties`:

- `enabled`: `{"type": "boolean"}`
- `global`: `{"type": "object", "additionalProperties": true}`

This is a standard pattern for Helm sub-charts with strict schemas (see [Helm docs on subcharts and global values](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/)).

## Testing

```bash
helm template test chart/ --set secret.GITLAB_PERSONAL_ACCESS_TOKEN=ok --set enabled=true --set global.imageRegistry=foo
```

Passes without error after the fix.