### PR TITLE
feat(mr): support viewing unresolved discussions on merge requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Added
+
+- **`unresolved_only` filter on `list_merge_request_discussions`** — pass `unresolved_only: true` to fetch only threads that still have at least one unresolved resolvable note. Filtering is performed client-side because the GitLab Discussions API has no server-side equivalent.
+- **Resolution metadata on MR discussion notes** — `GitLabNoteSchema` now models `resolved`, `resolved_by`, and `resolved_at`, so the resolution data GitLab returns for resolvable notes is no longer dropped at the Zod boundary.
+- **Per-thread `resolvable` / `resolved` aggregate** in `formatDiscussionsResponse` output, plus an `(N unresolved, M resolved threads)` count appended to the summary line whenever resolvable threads are present. Issue discussions (no resolvable notes) keep the legacy short summary.
+- **Tests** — 10 new vitest cases (96 total, up from 86) covering the new schema fields, formatter aggregation, and summary output.
 
 ## [0.8.1] - 2026-05-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",

--- a/src/formatters.test.ts
+++ b/src/formatters.test.ts
@@ -11,7 +11,8 @@ import {
   formatMilestonesResponse,
   formatProtectedBranchesResponse,
   formatUsersResponse,
-  formatGroupsResponse
+  formatGroupsResponse,
+  formatDiscussionsResponse
 } from './formatters.js';
 
 describe('formatPipelinesResponse', () => {
@@ -325,6 +326,160 @@ describe('formatUsersResponse', () => {
     const items = JSON.parse(response.content[1].text);
     expect(items[0].username).toBe('testuser');
     expect(items[0].name).toBe('Test User');
+  });
+});
+
+describe('formatDiscussionsResponse', () => {
+  const author = {
+    id: 1,
+    name: 'Reviewer',
+    username: 'rev',
+    avatar_url: null,
+    web_url: 'https://gitlab.example.com/rev'
+  };
+  const resolver = {
+    id: 2,
+    name: 'Maintainer',
+    username: 'maint',
+    avatar_url: null,
+    web_url: 'https://gitlab.example.com/maint'
+  };
+  const baseNote = {
+    attachment: null,
+    author,
+    system: false,
+    noteable_id: 1,
+    noteable_type: 'MergeRequest',
+  };
+
+  it('formats discussions and exposes per-note resolution fields', () => {
+    const response = formatDiscussionsResponse({
+      count: 1,
+      items: [
+        {
+          id: 'd1',
+          individual_note: false,
+          notes: [
+            {
+              ...baseNote,
+              id: 10,
+              body: 'Please rename this',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z',
+              resolvable: true,
+              resolved: true,
+              resolved_by: resolver,
+              resolved_at: '2024-01-02T00:00:00Z',
+            }
+          ]
+        }
+      ]
+    });
+
+    const items = JSON.parse(response.content[1].text);
+    expect(items[0].resolvable).toBe(true);
+    expect(items[0].resolved).toBe(true);
+    expect(items[0].notes[0].resolved).toBe(true);
+    expect(items[0].notes[0].resolved_by).toEqual({ name: 'Maintainer', username: 'maint' });
+    expect(items[0].notes[0].resolved_at).toBe('2024-01-02T00:00:00Z');
+  });
+
+  it('aggregates thread.resolved=false when any resolvable note is unresolved', () => {
+    const response = formatDiscussionsResponse({
+      count: 1,
+      items: [
+        {
+          id: 'd1',
+          individual_note: false,
+          notes: [
+            {
+              ...baseNote,
+              id: 10,
+              body: 'first',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z',
+              resolvable: true,
+              resolved: true,
+              resolved_by: resolver,
+              resolved_at: '2024-01-02T00:00:00Z',
+            },
+            {
+              ...baseNote,
+              id: 11,
+              body: 'reply',
+              created_at: '2024-01-03T00:00:00Z',
+              updated_at: '2024-01-03T00:00:00Z',
+              resolvable: true,
+              resolved: false,
+              resolved_by: null,
+              resolved_at: null,
+            }
+          ]
+        }
+      ]
+    });
+
+    const items = JSON.parse(response.content[1].text);
+    expect(items[0].resolvable).toBe(true);
+    expect(items[0].resolved).toBe(false);
+  });
+
+  it('reports unresolved/resolved counts in the summary', () => {
+    const response = formatDiscussionsResponse({
+      count: 3,
+      items: [
+        {
+          id: 'd1',
+          individual_note: false,
+          notes: [{
+            ...baseNote, id: 10, body: 'open', created_at: 't', updated_at: 't',
+            resolvable: true, resolved: false, resolved_by: null, resolved_at: null,
+          }]
+        },
+        {
+          id: 'd2',
+          individual_note: false,
+          notes: [{
+            ...baseNote, id: 11, body: 'done', created_at: 't', updated_at: 't',
+            resolvable: true, resolved: true, resolved_by: resolver, resolved_at: 't',
+          }]
+        },
+        {
+          id: 'd3',
+          individual_note: true,
+          notes: [{
+            ...baseNote, id: 12, body: 'plain', created_at: 't', updated_at: 't',
+          }]
+        }
+      ]
+    });
+
+    expect(response.content[0].text).toBe('Found 3 discussions (1 unresolved, 1 resolved threads)');
+  });
+
+  it('omits resolved aggregate on individual_note discussions (no resolvable notes)', () => {
+    const response = formatDiscussionsResponse({
+      count: 1,
+      items: [
+        {
+          id: 'd1',
+          individual_note: true,
+          notes: [{
+            ...baseNote,
+            id: 10,
+            body: 'just a comment',
+            created_at: 't',
+            updated_at: 't',
+          }]
+        }
+      ]
+    });
+
+    const items = JSON.parse(response.content[1].text);
+    expect(items[0].resolvable).toBe(false);
+    expect(items[0].resolved).toBeUndefined();
+    // Without any resolvable threads, the summary stays the legacy short form.
+    expect(response.content[0].text).toBe('Found 1 discussions');
   });
 });
 

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -327,26 +327,52 @@ export function formatNotesResponse(notes: GitLabNotesResponse) {
  * @returns A formatted response object for the MCP tool
  */
 export function formatDiscussionsResponse(discussions: GitLabDiscussionsResponse) {
-  // Create a summary of the discussions
-  const summary = `Found ${discussions.count} discussions`;
+  // Compute resolution stats so callers can see at a glance how many threads
+  // are still open. Individual notes (not part of a resolvable thread) are
+  // skipped — only resolvable discussions count toward resolved/unresolved.
+  const resolvableThreads = discussions.items.filter(d =>
+    d.notes.some(n => n.resolvable)
+  );
+  const unresolvedCount = resolvableThreads.filter(d =>
+    d.notes.some(n => n.resolvable && n.resolved === false)
+  ).length;
+  const resolvedCount = resolvableThreads.length - unresolvedCount;
+  const summary = resolvableThreads.length > 0
+    ? `Found ${discussions.count} discussions (${unresolvedCount} unresolved, ${resolvedCount} resolved threads)`
+    : `Found ${discussions.count} discussions`;
 
   // Format the discussions data
-  const formattedDiscussions = discussions.items.map(discussion => ({
-    id: discussion.id,
-    individual_note: discussion.individual_note,
-    notes: discussion.notes.map(note => ({
-      id: note.id,
-      body: note.body,
-      author: {
-        name: note.author.name,
-        username: note.author.username
-      },
-      created_at: note.created_at,
-      updated_at: note.updated_at,
-      system: note.system,
-      type: note.type || (note.system ? "system" : "comment")
-    }))
-  }));
+  const formattedDiscussions = discussions.items.map(discussion => {
+    const resolvable = discussion.notes.some(n => n.resolvable);
+    const resolved = resolvable
+      ? discussion.notes.every(n => !n.resolvable || n.resolved === true)
+      : undefined;
+    return {
+      id: discussion.id,
+      individual_note: discussion.individual_note,
+      resolvable,
+      resolved,
+      notes: discussion.notes.map(note => ({
+        id: note.id,
+        body: note.body,
+        author: {
+          name: note.author.name,
+          username: note.author.username
+        },
+        created_at: note.created_at,
+        updated_at: note.updated_at,
+        system: note.system,
+        type: note.type || (note.system ? "system" : "comment"),
+        resolvable: note.resolvable,
+        resolved: note.resolved,
+        resolved_by: note.resolved_by ? {
+          name: note.resolved_by.name,
+          username: note.resolved_by.username
+        } : undefined,
+        resolved_at: note.resolved_at ?? undefined
+      }))
+    };
+  });
 
   // Return the formatted response
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -427,7 +427,7 @@ const ALL_TOOLS = [
   },
   {
     name: "list_merge_request_discussions",
-    description: "List all discussions (threaded comments) on a merge request",
+    description: "List discussions (threaded comments) on a merge request. Pass unresolved_only=true to filter to threads that still have at least one unresolved note.",
     inputSchema: createJsonSchema(ListMergeRequestDiscussionsSchema),
     readOnly: true
   },
@@ -1321,6 +1321,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             per_page: args.per_page
           }
         );
+
+        if (args.unresolved_only) {
+          const filteredItems = discussions.items.filter(d =>
+            d.notes.some(n => n.resolvable && n.resolved === false)
+          );
+          return formatDiscussionsResponse({
+            count: filteredItems.length,
+            items: filteredItems
+          });
+        }
 
         return formatDiscussionsResponse(discussions);
       }

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -33,6 +33,7 @@ import {
   UpdateMergeRequestSchema,
   RebaseMergeRequestSchema,
   CreateMergeRequestDiscussionSchema,
+  ListMergeRequestDiscussionsSchema,
   // Protected Branch Schemas
   ListProtectedBranchesSchema,
   ProtectBranchSchema,
@@ -54,6 +55,7 @@ import {
   // Response Schemas
   GitLabUserSchema,
   GitLabMemberSchema,
+  GitLabNoteSchema,
 } from './schemas.js';
 
 describe('CI/CD Schemas', () => {
@@ -247,6 +249,36 @@ describe('MR Enhancement Schemas', () => {
     });
   });
 
+  describe('ListMergeRequestDiscussionsSchema', () => {
+    it('requires project_id and merge_request_iid', () => {
+      expect(() => ListMergeRequestDiscussionsSchema.parse({ project_id: 'test' })).toThrow();
+      expect(ListMergeRequestDiscussionsSchema.parse({
+        project_id: 'test',
+        merge_request_iid: 1
+      })).toEqual({
+        project_id: 'test',
+        merge_request_iid: 1
+      });
+    });
+
+    it('accepts unresolved_only filter', () => {
+      const valid = ListMergeRequestDiscussionsSchema.parse({
+        project_id: 'test',
+        merge_request_iid: 1,
+        unresolved_only: true
+      });
+      expect(valid.unresolved_only).toBe(true);
+    });
+
+    it('rejects non-boolean unresolved_only', () => {
+      expect(() => ListMergeRequestDiscussionsSchema.parse({
+        project_id: 'test',
+        merge_request_iid: 1,
+        unresolved_only: 'yes'
+      })).toThrow();
+    });
+  });
+
   describe('RebaseMergeRequestSchema', () => {
     it('requires project_id and merge_request_iid', () => {
       expect(RebaseMergeRequestSchema.parse({
@@ -385,6 +417,62 @@ describe('Response schemas — GitLab EE nullability', () => {
         web_url: 'https://gitlab.example.com/lite'
       });
       expect(parsed.avatar_url).toBeUndefined();
+    });
+  });
+
+  describe('GitLabNoteSchema — resolution fields', () => {
+    const baseAuthor = {
+      id: 1,
+      name: 'Reviewer',
+      username: 'rev',
+      avatar_url: null,
+      web_url: 'https://gitlab.example.com/rev'
+    };
+    const baseNote = {
+      id: 100,
+      body: 'Please address this',
+      attachment: null,
+      author: baseAuthor,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      system: false,
+      noteable_id: 1,
+      noteable_type: 'MergeRequest',
+    };
+
+    it('parses an unresolved resolvable note', () => {
+      const parsed = GitLabNoteSchema.parse({
+        ...baseNote,
+        resolvable: true,
+        resolved: false,
+        resolved_by: null,
+        resolved_at: null,
+      });
+      expect(parsed.resolvable).toBe(true);
+      expect(parsed.resolved).toBe(false);
+      expect(parsed.resolved_by).toBeNull();
+      expect(parsed.resolved_at).toBeNull();
+    });
+
+    it('parses a resolved note with resolver metadata', () => {
+      const parsed = GitLabNoteSchema.parse({
+        ...baseNote,
+        resolvable: true,
+        resolved: true,
+        resolved_by: { ...baseAuthor, id: 2, username: 'maintainer', name: 'Maintainer' },
+        resolved_at: '2024-01-02T10:00:00Z',
+      });
+      expect(parsed.resolved).toBe(true);
+      expect(parsed.resolved_by?.username).toBe('maintainer');
+      expect(parsed.resolved_at).toBe('2024-01-02T10:00:00Z');
+    });
+
+    it('parses a note where resolution fields are omitted (issue notes)', () => {
+      const parsed = GitLabNoteSchema.parse(baseNote);
+      expect(parsed.resolvable).toBeUndefined();
+      expect(parsed.resolved).toBeUndefined();
+      expect(parsed.resolved_by).toBeUndefined();
+      expect(parsed.resolved_at).toBeUndefined();
     });
   });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -22,6 +22,9 @@ export const GitLabNoteSchema = z.object({
   noteable_type: z.string(),
   noteable_iid: z.number().optional(),
   resolvable: z.boolean().optional(),
+  resolved: z.boolean().optional(),
+  resolved_by: z.lazy(() => GitLabUserSchema).nullable().optional(),
+  resolved_at: z.string().nullable().optional(),
   confidential: z.boolean().optional(),
   internal: z.boolean().optional(),
   type: z.string().nullable().optional(), // For system notes, indicates the type of change
@@ -750,6 +753,7 @@ export const ListMergeRequestDiscussionsSchema = z.object({
   merge_request_iid: z.number().describe("MR internal ID"),
   page: z.number().optional().describe("Page number (1-indexed)"),
   per_page: z.number().optional().describe("Results per page (1-100)"),
+  unresolved_only: z.boolean().optional().describe("If true, return only discussions that are resolvable and have at least one unresolved note"),
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

  `list_merge_request_discussions` previously dropped GitLab's resolution metadata
  (`resolved`, `resolved_by`, `resolved_at`) at the Zod boundary, leaving callers
  with no way to tell which MR review threads were still open. This PR threads
  that data all the way through — schema → formatter → tool output — and adds an
  `unresolved_only` filter so callers can fetch just the threads still needing
  attention. Fully additive: existing responses gain new optional fields, none
  are removed or renamed.

  Closes #

  ## Type of change

  - [x] feat — new functionality
  - [x] test — adds or improves tests
  - [x] chore — tooling, deps, infra

  ## Pre-merge checklist

  - [x] `package.json` version bumped — 0.8.1 → 0.9.0 (MINOR, new functionality)
  - [x] `CHANGELOG.md` entry added under `## [Unreleased]`
  - [x] `npm test` passes (vitest — 96/96, +10 new)
  - [x] `npm run build` passes
  - [x] Conventional Commits format on commit subject — `feat(mr):` and `chore(release):`
  - [x] No secrets, tokens, or `.env` values in the diff
  - [ ] Branch named `feature/*`, `fix/*`, `docs/*`, or `refactor/*` _(committed directly on `main` in this fork; will need a feature branch if PR'd back upstream)_
  - [x] Touching `src/index.ts` — `list_merge_request_discussions` retains `readOnly: true`; no impact on session lifecycle, token handling, or read-only mode

  ## For breaking changes

  _Not applicable — fully additive change. The new fields on note objects and the
  new optional argument on the tool are backwards-compatible with existing callers._

  ## Notes for reviewer

  **What changed, file by file**

  - `src/schemas.ts` — `GitLabNoteSchema` gains `resolved` / `resolved_by` / `resolved_at` (all optional, with `resolved_by` reusing `GitLabUserSchema` and nullable). `ListMergeRequestDiscussionsSchema` gains
  optional `unresolved_only: boolean`.
  - `src/formatters.ts` — `formatDiscussionsResponse` now emits per-note resolution fields, computes a thread-level `resolvable`/`resolved` aggregate, and appends `(N unresolved, M resolved threads)` to the summary
   line when any resolvable thread exists.
  - `src/index.ts` — handler for `list_merge_request_discussions` filters discussions by `notes.some(n => n.resolvable && n.resolved === false)` when `unresolved_only=true`. Tool description updated.
  - `src/schemas.test.ts` / `src/formatters.test.ts` — 10 new vitest cases.

  **Design choices to look at**

  - **Client-side filtering.** The GitLab Discussions API has no server-side `unresolved` filter, so the handler fetches the requested page(s) first, then filters. This mirrors every other list tool in the server.
  For MRs with hundreds of discussions and aggressive pagination, callers should be aware they pay the full fetch cost.
  - **Thread `resolved` semantics.** A thread is reported as resolved only when _all_ its resolvable notes are resolved (`notes.every(n => !n.resolvable || n.resolved === true)`), matching the GitLab UI definition.
   Mixed threads (some resolved, some not) report `resolved=false`.
  - **Issue discussions are unaffected.** Issue notes are never resolvable, so `formatDiscussionsResponse` falls through to the legacy short summary and the new fields surface as `undefined` for
  `list_issue_discussions` — no behavioral change for that tool.

  **Test coverage added**

  - `GitLabNoteSchema`: unresolved resolvable note, resolved note with resolver metadata, note where the resolution fields are omitted entirely (issue-note path).
  - `ListMergeRequestDiscussionsSchema`: required fields, accepts `unresolved_only: boolean`, rejects non-boolean.
  - `formatDiscussionsResponse`: per-note resolution fields pass through; multi-note thread with one unresolved note aggregates to `resolved=false`; summary count line for mixed threads; individual-note path keeps
  the legacy short summary and emits no `resolved` aggregate.