### PR TITLE
feat: pipeline investigation tools (closes #64, supersedes #86)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ implementation/
 mempalace.yaml
 .mempalace/
 entities.json
+.helm-pkg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet. New entries land here between releases._
+### Added
+
+- **`get_pipeline_summary` tool** — single-call pipeline investigation returning
+  pipeline details, jobs grouped by stage, and log tails for failed jobs. Includes
+  failure pattern detection and `max_failed_jobs_with_logs` cap (default: 5) to
+  prevent context blowup. (#64)
+- **`get_job_log_smart` tool** — intelligent log post-processor that strips ANSI
+  codes, GitLab timestamps, and section markers. Supports `tail`/`head`, section
+  extraction, and `error_only` filtering. (#64)
+- **`list_pipeline_jobs` extension** — new optional `include_log_tail` and
+  `log_tail_lines` parameters. When `include_log_tail=true`, failed jobs include
+  their cleaned log tail directly in the response. (#64)
 
 ## [0.8.1] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `shared_reason`. Previously the mixed branch silently dropped failed jobs
   whose `failure_reason` was missing/empty from the visible reason histogram.
   (#99 codex)
+- **`get_job_log_smart` section extraction is now exact-match.** The previous
+  regex `section_start:\d+:NAME[^\n]*\n?` accepted a prefix match - requesting
+  `section: "build"` would silently return `build_extra` content with
+  `section_matched: true`. Now uses a lookahead `(?=[\r\n\[]|$)` after the
+  name to require GitLab's actual section delimiters. (#99 codex P2 round-2)
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`get_job_log_smart` tool** — intelligent log post-processor that strips ANSI
   codes, GitLab timestamps, and section markers. Supports `tail`/`head`, section
   extraction, and `error_only` filtering. (#64)
-- **`list_pipeline_jobs` extension** — new optional `include_log_tail` and
-  `log_tail_lines` parameters. When `include_log_tail=true`, failed jobs include
-  their cleaned log tail directly in the response. (#64)
+- **`list_pipeline_jobs` extension** — new optional `include_log_tail`,
+  `log_tail_lines`, and `max_log_tail_jobs` parameters. When `include_log_tail=true`,
+  failed jobs include their cleaned log tail directly in the response. (#64)
+- **`truncated` field** in `get_pipeline_summary` response — signals when pagination
+  cap (50 pages) was hit and job list may be incomplete.
+- **`section_matched` and `error_lines_matched` fields** in `get_job_log_smart`
+  response — explicit feedback on filter effectiveness.
+- **`log_fetch_errors` field** in pipeline summary — surfaces per-job log fetch
+  failures instead of silently swallowing them.
+
+### Changed
+
+- **Renamed** `log_lines` → `log_tail_lines` in `get_pipeline_summary` schema for
+  consistency with `list_pipeline_jobs`. (#64 review)
+- **`failure_pattern`** is now a discriminated union (`shared_reason | mixed |
+  no_failures | null`) instead of a plain string. (#64 review)
+- **Stage status derivation** now mirrors GitLab's aggregation: `allow_failure`
+  jobs no longer poison the stage; mixed success+skipped collapses to success.
+  (#64 review)
+- **Pagination** no longer relies on `X-Total` header (absent in GitLab EE);
+  uses `items.length < per_page` with a MAX_PAGES=50 safety cap. (#64 review)
+
+### Fixed
+
+- **`error_only` mode** in `get_job_log_smart` now correctly returns an empty log
+  (instead of the full log) when no error-like lines are found. (#64 review)
+- **Silent log fetch failures** — `getJobLogTails` and `getPipelineSummary` now
+  track and report errors per job instead of empty catch blocks. (#64 review)
+- **E2E tests** — assertions moved outside try/catch so test failures propagate
+  correctly; try/catch narrowed to the fetch step only. (#64 review)
+
+### Security
+
+- Schema parameters now have strict `.int().min().max()` bounds to prevent
+  abuse (e.g., `log_tail_lines` capped at 200, `max_log_tail_jobs` at 20).
+- XOR validation via `.refine()` on mutually exclusive parameters
+  (`pipeline_id`/`ref`, `tail`/`head`).
 
 ## [0.8.1] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `section: "build"` would silently return `build_extra` content with
   `section_matched: true`. Now uses a lookahead `(?=[\r\n\[]|$)` after the
   name to require GitLab's actual section delimiters. (#99 codex P2 round-2)
+- **`stripSections` now consumes both CR and LF after the marker.** GitLab's
+  section line `section_*:NNN:name\r\x1B[0K\n` collapses to
+  `section_*:NNN:name\r\n` after ANSI stripping; the previous regex tail
+  `[\r\n]?` consumed only one of CR/LF, leaving an orphan `\n` per marker.
+  Cleaned logs had spurious blank lines and `tail: N` could shift by an
+  empty line. New regex tail `\r?\n?` consumes the full CRLF combo.
+  (#99 codex P2 round-3)
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Renamed** `log_lines` → `log_tail_lines` in `get_pipeline_summary` schema for
   consistency with `list_pipeline_jobs`. (#64 review)
-- **`failure_pattern`** is now a discriminated union (`shared_reason | mixed |
-  no_failures | null`) instead of a plain string. (#64 review)
+- **`failure_pattern`** is now an exhaustive discriminated union
+  (`no_failures | single | shared_reason | mixed | unknown`) instead of a
+  plain string. The `shared_reason` variant carries `unreasoned_count` so
+  callers can tell when some failed jobs lacked a `failure_reason` (vs.
+  every failure sharing the same reason). (#64 review)
 - **Stage status derivation** now mirrors GitLab's aggregation: `allow_failure`
   jobs no longer poison the stage; mixed success+skipped collapses to success.
   (#64 review)
@@ -46,6 +49,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   track and report errors per job instead of empty catch blocks. (#64 review)
 - **E2E tests** — assertions moved outside try/catch so test failures propagate
   correctly; try/catch narrowed to the fetch step only. (#64 review)
+- **`list_pipeline_jobs` (`include_log_tail=true`)** now always emits the
+  unified `{jobs, log_fetch_errors?}` wrapper, including the zero-failed-jobs
+  fallback path that previously reverted to the legacy flat-array shape.
+  (#64 round-3 follow-up)
+- **`get_job_log_smart`** returns `line_count: 0` for an empty log instead of
+  the JS-quirk `1` from `''.split('\n')`. Faithful counts on the
+  section-not-found and `error_only` no-match paths. (#64 round-3 follow-up)
+- **`FailurePattern.single.reason`** normalizes empty-string `failure_reason`
+  to `null` (was passed through verbatim by `??`). Aligns with `.filter(Boolean)`
+  semantics used by the multi-job variants. (#64 round-3 follow-up)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without any signal that more failed jobs existed. (#99 pre-push
   silent-failure-hunter)
 
+### Fixed (round 5)
+
+- **`tail: 1` on a single-line log no longer returns `""`.** The previous
+  `logTail` walked all `\n` from the end including the trailing
+  terminator, so `tail: 1` on `"ERROR\n"` returned the empty string and
+  `log_tail_lines: 50` returned only 49 real lines. `logTail`/`logHead`/
+  `countLines` now treat a single trailing `\n` as the line terminator
+  via an `endIdx` bound, preserving the O(tail) memory promise.
+  (#99 codex P2 round-5)
+- **`stripSections` now consumes `\x1B[0K` clear-control bytes between
+  CR and LF.** When `strip_ansi: false`, the section-stripping path runs
+  on raw GitLab markers `section_*:NNN:name\r\x1B[0K\n` - the previous
+  regex tail `\r?\n?` left orphan `\x1B[0K\n` fragments in the cleaned
+  log. New tail `\r?(?:\x1B\[[0-9;]*[a-zA-Z])*\n?` consumes any inline
+  ANSI escapes between CR and LF, working whether ANSI was pre-stripped
+  or not. (#99 codex P2 round-5)
+- **`get_job_log_smart.log` is shape-stable across the truncation
+  boundary.** The same tool no longer returns `"L\n"` for `tail: 50`
+  (no truncation) and `"L"` for `tail: 49` (truncation kicks in) on the
+  same 50-line input. Unconditional strip of a single trailing `\n` at
+  the end of the helper. (#99 pre-push silent-failure-hunter)
+
 ### Performance
 
 - **Job log tail/head/section/error_only extraction** in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consistency with `list_pipeline_jobs`. (#64 review)
 - **`failure_pattern`** is now an exhaustive discriminated union
   (`no_failures | single | shared_reason | mixed | unknown`) instead of a
-  plain string. The `shared_reason` variant carries `unreasoned_count` so
-  callers can tell when some failed jobs lacked a `failure_reason` (vs.
-  every failure sharing the same reason). (#64 review)
+  plain string. Both `shared_reason` and `mixed` variants carry
+  `unreasoned_count` so callers can tell when some failed jobs lacked a
+  `failure_reason` (the invariant `sum(reasons) + unreasoned_count ===
+  failedJobs.length` holds for both). (#64 review + #99 codex)
 - **Stage status derivation** now mirrors GitLab's aggregation: `allow_failure`
   jobs no longer poison the stage; mixed success+skipped collapses to success.
   (#64 review)
@@ -59,6 +60,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`FailurePattern.single.reason`** normalizes empty-string `failure_reason`
   to `null` (was passed through verbatim by `??`). Aligns with `.filter(Boolean)`
   semantics used by the multi-job variants. (#64 round-3 follow-up)
+- **`FailurePattern.mixed`** gains `unreasoned_count` for parity with
+  `shared_reason`. Previously the mixed branch silently dropped failed jobs
+  whose `failure_reason` was missing/empty from the visible reason histogram.
+  (#99 codex)
+
+### Performance
+
+- **Job log tail/head/section/error_only extraction** in
+  `get_pipeline_summary`, `get_job_log_smart`, and `list_pipeline_jobs +
+  include_log_tail` is now O(K) in memory instead of O(N) — the previous
+  `log.split('\n').slice(-N).join('\n')` pattern allocated an array of all
+  lines just to keep the last/first K. New private helpers (`logTail`,
+  `logHead`, `countLines`) walk newlines via `lastIndexOf` / `indexOf` /
+  `charCodeAt`. Section extraction uses `RegExp.lastIndex` instead of
+  `rawLog.slice(startIdx)` to avoid copying multi-MB log strings.
+  `error_only` filtering uses a single `gim` regex match instead of
+  split + filter + join. (#99 gemini)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Cleaned logs had spurious blank lines and `tail: N` could shift by an
   empty line. New regex tail `\r?\n?` consumes the full CRLF combo.
   (#99 codex P2 round-3)
+- **`sections_found` surfaces the bare section name.** Previously emitted
+  `"script[collapsed=true]"` verbatim, which is unusable as a follow-up
+  `section:` argument (end markers never carry the `[option]` suffix and
+  would never match). Now strips the `[...]` collapsed-marker tail after
+  ANSI removal. (#99 codex P2 round-4)
+- **`pipeline_id: 0` no longer silently falls through to "latest pipeline".**
+  Schema now requires `z.number().int().positive()` and the runtime path
+  selector uses `!== undefined`. Previously a JS truthy check disagreed
+  with the schema's XOR refine. (#99 pre-push silent-failure-hunter)
+- **`section: ""` no longer silently skipped.** Schema now requires
+  `z.string().min(1)`; empty-string requests fail at parse instead of
+  silently returning the full log with `section_matched: null`.
+  (#99 pre-push silent-failure-hunter)
+- **`section` matching is now case-SENSITIVE.** Dropped the regex `i` flag.
+  GitLab section names are identifiers and case-insensitive matching
+  would create silent ambiguity between sibling sections like `Build`
+  and `build`. Aligns with the "exact-match" contract introduced in the
+  codex P2 round-2 fix. (#99 pre-push silent-failure-hunter LOW-2)
+- **Section markers are stripped regardless of `strip_ansi`.** Previously
+  section-marker stripping was bound to the `strip_ansi: true` path; a
+  caller debugging raw ANSI output would see raw `section_start:NNN:name`
+  bytes leak into `tail`/`head` windows. Section markers are unconditionally
+  noise and are now always stripped. (#99 pre-push code-simplifier)
+
+### Added
+
+- **`log_fetch_capped` field** in `get_pipeline_summary` summary and in
+  the `list_pipeline_jobs + include_log_tail` wrapper. Present as
+  `{ fetched: number; total_failed: number }` when the helper intentionally
+  skipped log-fetching for failed jobs beyond the cap
+  (`max_failed_jobs_with_logs` default 5, `max_log_tail_jobs` default 10).
+  Closes a silent fallback where callers saw a partial set of log tails
+  without any signal that more failed jobs existed. (#99 pre-push
+  silent-failure-hunter)
 
 ### Performance
 

--- a/e2e/src/tests/pipelines.e2e.ts
+++ b/e2e/src/tests/pipelines.e2e.ts
@@ -285,4 +285,130 @@ describe('Pipeline & Job tools', () => {
 
     // No retryable job found — not a failure, just skip
   });
+
+  // ===========================================================================
+  // Pipeline Investigation Tools (issue #64)
+  // ===========================================================================
+
+  it('get_pipeline_summary — returns structured pipeline summary with stages', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_pipeline_summary',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+      },
+    });
+    const data = extractJson<{
+      pipeline: { id: number; ref: string; status: string };
+      stages: Array<{ name: string; status: string; jobs: Array<{ id: number; name: string }> }>;
+      summary: { total_jobs: number; passed: number; failed: number };
+    }>(result);
+
+    expect(data.pipeline.id).toBeGreaterThan(0);
+    expect(data.pipeline.ref).toBe('main');
+    expect(data.stages.length).toBeGreaterThan(0);
+    expect(data.stages[0].name).toBeDefined();
+    expect(data.stages[0].jobs.length).toBeGreaterThan(0);
+    expect(data.summary.total_jobs).toBeGreaterThan(0);
+  });
+
+  it('get_pipeline_summary — accepts ref parameter', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_pipeline_summary',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        ref: 'main',
+        include_logs: false,
+      },
+    });
+    const data = extractJson<{
+      pipeline: { id: number; ref: string };
+      stages: Array<{ name: string; jobs: Array<{ log_tail?: string }> }>;
+    }>(result);
+
+    expect(data.pipeline.ref).toBe('main');
+    // When include_logs is false, no log_tail should be present
+    for (const stage of data.stages) {
+      for (const job of stage.jobs) {
+        expect(job.log_tail).toBeUndefined();
+      }
+    }
+  });
+
+  it('get_pipeline_summary — accepts pipeline_id parameter', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'get_pipeline_summary',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        pipeline_id: pipelineId,
+      },
+    });
+    const data = extractJson<{ pipeline: { id: number } }>(result);
+    expect(data.pipeline.id).toBe(pipelineId);
+  });
+
+  it('get_job_log_smart — returns cleaned log output', async () => {
+    // Wait for job to have produced output
+    await new Promise((r) => setTimeout(r, 3000));
+
+    try {
+      const result = await globalThis.mcpClient.callTool({
+        name: 'get_job_log_smart',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          job_id: jobId,
+          tail: 10,
+        },
+      });
+      const data = extractJson<{
+        job_id: number;
+        log: string;
+        line_count: number;
+        truncated: boolean;
+        sections_found: string[];
+      }>(result);
+
+      expect(data.job_id).toBe(jobId);
+      expect(data.line_count).toBeGreaterThan(0);
+      expect(typeof data.truncated).toBe('boolean');
+      expect(Array.isArray(data.sections_found)).toBe(true);
+      // Verify ANSI codes are stripped (should not contain escape sequences)
+      expect(data.log).not.toMatch(/\x1B\[/);
+    } catch {
+      // Job trace not available in CI — acceptable
+    }
+  });
+
+  it('get_job_log_smart — error_only filter works', async () => {
+    try {
+      const result = await globalThis.mcpClient.callTool({
+        name: 'get_job_log_smart',
+        arguments: {
+          project_id: String(globalThis.fixtures.projectId),
+          job_id: jobId,
+          error_only: true,
+        },
+      });
+      const data = extractJson<{ job_id: number; log: string }>(result);
+      expect(data.job_id).toBe(jobId);
+      // error_only returns either error lines or the full log if no errors detected
+      expect(typeof data.log).toBe('string');
+    } catch {
+      // Job trace not available in CI — acceptable
+    }
+  });
+
+  it('list_pipeline_jobs — include_log_tail extension returns logs for failed jobs', async () => {
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_pipeline_jobs',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        pipeline_id: pipelineId,
+        include_log_tail: true,
+        log_tail_lines: 10,
+      },
+    });
+    // Whether or not there are failed jobs, the call should succeed
+    const text = extractText(result);
+    expect(text.length).toBeGreaterThan(0);
+  });
 });

--- a/e2e/src/tests/pipelines.e2e.ts
+++ b/e2e/src/tests/pipelines.e2e.ts
@@ -373,8 +373,9 @@ describe('Pipeline & Job tools', () => {
       expect(Array.isArray(data.sections_found)).toBe(true);
       // Verify ANSI codes are stripped (should not contain escape sequences)
       expect(data.log).not.toMatch(/\x1B\[/);
-    } catch {
+    } catch (e) {
       // Job trace not available in CI — acceptable
+      console.warn('get_job_log_smart test skipped:', e);
     }
   });
 
@@ -392,8 +393,9 @@ describe('Pipeline & Job tools', () => {
       expect(data.job_id).toBe(jobId);
       // error_only returns either error lines or the full log if no errors detected
       expect(typeof data.log).toBe('string');
-    } catch {
+    } catch (e) {
       // Job trace not available in CI — acceptable
+      console.warn('get_job_log_smart error_only test skipped:', e);
     }
   });
 

--- a/e2e/src/tests/pipelines.e2e.ts
+++ b/e2e/src/tests/pipelines.e2e.ts
@@ -435,7 +435,7 @@ describe('Pipeline & Job tools', () => {
     }
   });
 
-  it('list_pipeline_jobs — include_log_tail extension returns logs for failed jobs', async () => {
+  it('list_pipeline_jobs — include_log_tail returns unified wrapper shape on all paths', async () => {
     const result = await globalThis.mcpClient.callTool({
       name: 'list_pipeline_jobs',
       arguments: {
@@ -445,8 +445,57 @@ describe('Pipeline & Job tools', () => {
         log_tail_lines: 10,
       },
     });
-    // Whether or not there are failed jobs, the call should succeed
-    const text = extractText(result);
-    expect(text.length).toBeGreaterThan(0);
+
+    // Contract: when include_log_tail=true, response shape is ALWAYS
+    // { jobs: [...], log_fetch_errors?: [...] } regardless of whether failed
+    // jobs exist or log fetches errored. Verifies the round-3 fallback fix.
+    const data = extractJson<{
+      jobs: Array<{ id: number; name: string; status: string; log_tail?: string }>;
+      log_fetch_errors?: Array<{ job_id: number; error: string }>;
+    }>(result);
+
+    expect(Array.isArray(data.jobs)).toBe(true);
+    expect(data.jobs.length).toBeGreaterThan(0);
+    // Every job in the wrapper has at least id/name/status from the base schema
+    for (const job of data.jobs) {
+      expect(typeof job.id).toBe('number');
+      expect(typeof job.name).toBe('string');
+      expect(typeof job.status).toBe('string');
+    }
+    // If any failed jobs were present, they should carry log_tail (best-effort)
+    const failedWithLogs = data.jobs.filter(j => j.status === 'failed' && typeof j.log_tail === 'string');
+    const failedTotal = data.jobs.filter(j => j.status === 'failed').length;
+    if (failedTotal > 0) {
+      // log_tail attachment is best-effort; either tails populated or errors recorded
+      const errorsLen = data.log_fetch_errors?.length ?? 0;
+      expect(failedWithLogs.length + errorsLen).toBeGreaterThan(0);
+    }
+  });
+
+  it('list_pipeline_jobs — include_log_tail wrapper holds even with zero failed jobs (round-3 fallback fix)', async () => {
+    // Filter to a status that won't have failures - the wrapper shape must
+    // still apply even when slicedIds is empty (regression test for the
+    // round-3 bug where formatJobsResponse leaked through).
+    const result = await globalThis.mcpClient.callTool({
+      name: 'list_pipeline_jobs',
+      arguments: {
+        project_id: String(globalThis.fixtures.projectId),
+        pipeline_id: pipelineId,
+        include_log_tail: true,
+        scope: ['success'], // explicit non-failed scope
+        log_tail_lines: 10,
+      },
+    });
+
+    // The response MUST be the wrapper shape, not a flat array
+    const data = extractJson<{
+      jobs: unknown;
+      log_fetch_errors?: unknown;
+    }>(result);
+
+    expect(data).toHaveProperty('jobs');
+    expect(Array.isArray(data.jobs)).toBe(true);
+    // No failed jobs → no log_fetch_errors field expected
+    expect(data.log_fetch_errors).toBeUndefined();
   });
 });

--- a/e2e/src/tests/pipelines.e2e.ts
+++ b/e2e/src/tests/pipelines.e2e.ts
@@ -300,7 +300,14 @@ describe('Pipeline & Job tools', () => {
     const data = extractJson<{
       pipeline: { id: number; ref: string; status: string };
       stages: Array<{ name: string; status: string; jobs: Array<{ id: number; name: string }> }>;
-      summary: { total_jobs: number; passed: number; failed: number };
+      truncated: boolean;
+      summary: {
+        total_jobs: number;
+        passed: number;
+        failed: number;
+        failure_pattern: { kind: string } | null;
+        log_fetch_errors?: Array<{ job_id: number; error: string }>;
+      };
     }>(result);
 
     expect(data.pipeline.id).toBeGreaterThan(0);
@@ -309,6 +316,11 @@ describe('Pipeline & Job tools', () => {
     expect(data.stages[0].name).toBeDefined();
     expect(data.stages[0].jobs.length).toBeGreaterThan(0);
     expect(data.summary.total_jobs).toBeGreaterThan(0);
+    expect(typeof data.truncated).toBe('boolean');
+    // failure_pattern is either null or a discriminated union with 'kind'
+    if (data.summary.failure_pattern !== null) {
+      expect(data.summary.failure_pattern.kind).toBeDefined();
+    }
   });
 
   it('get_pipeline_summary — accepts ref parameter', async () => {
@@ -350,8 +362,9 @@ describe('Pipeline & Job tools', () => {
     // Wait for job to have produced output
     await new Promise((r) => setTimeout(r, 3000));
 
+    let result;
     try {
-      const result = await globalThis.mcpClient.callTool({
+      result = await globalThis.mcpClient.callTool({
         name: 'get_job_log_smart',
         arguments: {
           project_id: String(globalThis.fixtures.projectId),
@@ -359,29 +372,36 @@ describe('Pipeline & Job tools', () => {
           tail: 10,
         },
       });
-      const data = extractJson<{
-        job_id: number;
-        log: string;
-        line_count: number;
-        truncated: boolean;
-        sections_found: string[];
-      }>(result);
-
-      expect(data.job_id).toBe(jobId);
-      expect(data.line_count).toBeGreaterThan(0);
-      expect(typeof data.truncated).toBe('boolean');
-      expect(Array.isArray(data.sections_found)).toBe(true);
-      // Verify ANSI codes are stripped (should not contain escape sequences)
-      expect(data.log).not.toMatch(/\x1B\[/);
     } catch (e) {
-      // Job trace not available in CI — acceptable
-      console.warn('get_job_log_smart test skipped:', e);
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/job (trace|log) (not|unavailable)/i.test(msg) || /404/.test(msg)) {
+        return; // legitimate skip — trace not available in CI
+      }
+      throw e; // real regression
     }
+
+    const data = extractJson<{
+      job_id: number;
+      log: string;
+      line_count: number;
+      truncated: boolean;
+      sections_found: string[];
+      section_matched?: boolean;
+      error_lines_matched?: number;
+    }>(result);
+
+    expect(data.job_id).toBe(jobId);
+    expect(data.line_count).toBeGreaterThan(0);
+    expect(typeof data.truncated).toBe('boolean');
+    expect(Array.isArray(data.sections_found)).toBe(true);
+    // Verify ANSI codes are stripped (should not contain escape sequences)
+    expect(data.log).not.toMatch(/\x1B\[/);
   });
 
-  it('get_job_log_smart — error_only filter works', async () => {
+  it('get_job_log_smart — error_only returns empty log when no errors', async () => {
+    let result;
     try {
-      const result = await globalThis.mcpClient.callTool({
+      result = await globalThis.mcpClient.callTool({
         name: 'get_job_log_smart',
         arguments: {
           project_id: String(globalThis.fixtures.projectId),
@@ -389,13 +409,26 @@ describe('Pipeline & Job tools', () => {
           error_only: true,
         },
       });
-      const data = extractJson<{ job_id: number; log: string }>(result);
-      expect(data.job_id).toBe(jobId);
-      // error_only returns either error lines or the full log if no errors detected
-      expect(typeof data.log).toBe('string');
     } catch (e) {
-      // Job trace not available in CI — acceptable
-      console.warn('get_job_log_smart error_only test skipped:', e);
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/job (trace|log) (not|unavailable)/i.test(msg) || /404/.test(msg)) {
+        return; // legitimate skip
+      }
+      throw e;
+    }
+
+    const data = extractJson<{
+      job_id: number;
+      log: string;
+      error_lines_matched: number;
+    }>(result);
+
+    expect(data.job_id).toBe(jobId);
+    expect(typeof data.error_lines_matched).toBe('number');
+    // Our test job echoes "E2E pipeline test" — no error keywords
+    // So error_lines_matched should be 0 and log should be empty
+    if (data.error_lines_matched === 0) {
+      expect(data.log).toBe('');
     }
   });
 

--- a/e2e/src/tests/pipelines.e2e.ts
+++ b/e2e/src/tests/pipelines.e2e.ts
@@ -305,7 +305,7 @@ describe('Pipeline & Job tools', () => {
         total_jobs: number;
         passed: number;
         failed: number;
-        failure_pattern: { kind: string } | null;
+        failure_pattern: { kind: string };
         log_fetch_errors?: Array<{ job_id: number; error: string }>;
       };
     }>(result);
@@ -317,10 +317,9 @@ describe('Pipeline & Job tools', () => {
     expect(data.stages[0].jobs.length).toBeGreaterThan(0);
     expect(data.summary.total_jobs).toBeGreaterThan(0);
     expect(typeof data.truncated).toBe('boolean');
-    // failure_pattern is either null or a discriminated union with 'kind'
-    if (data.summary.failure_pattern !== null) {
-      expect(data.summary.failure_pattern.kind).toBeDefined();
-    }
+    // failure_pattern is always present as a discriminated union with 'kind'
+    expect(data.summary.failure_pattern.kind).toBeDefined();
+    expect(['no_failures', 'single', 'shared_reason', 'mixed', 'unknown']).toContain(data.summary.failure_pattern.kind);
   });
 
   it('get_pipeline_summary — accepts ref parameter', async () => {
@@ -386,14 +385,18 @@ describe('Pipeline & Job tools', () => {
       line_count: number;
       truncated: boolean;
       sections_found: string[];
-      section_matched?: boolean;
-      error_lines_matched?: number;
+      section_matched: boolean | null;
+      error_lines_matched: number | null;
     }>(result);
 
     expect(data.job_id).toBe(jobId);
     expect(data.line_count).toBeGreaterThan(0);
     expect(typeof data.truncated).toBe('boolean');
     expect(Array.isArray(data.sections_found)).toBe(true);
+    // section_matched is null when section param not passed
+    expect(data.section_matched).toBeNull();
+    // error_lines_matched is null when error_only not passed
+    expect(data.error_lines_matched).toBeNull();
     // Verify ANSI codes are stripped (should not contain escape sequences)
     expect(data.log).not.toMatch(/\x1B\[/);
   });
@@ -420,7 +423,7 @@ describe('Pipeline & Job tools', () => {
     const data = extractJson<{
       job_id: number;
       log: string;
-      error_lines_matched: number;
+      error_lines_matched: number | null;
     }>(result);
 
     expect(data.job_id).toBe(jobId);

--- a/src/gitlab-api.test.ts
+++ b/src/gitlab-api.test.ts
@@ -380,6 +380,62 @@ describe('GitLabApi.getJobLogSmart - section marker stripping (CRLF)', () => {
     expect(result.sections_found).not.toContain('script[collapsed=true]');
   });
 
+  it('strips raw `\\x1B[0K` clear-control between section name and LF even without prior ANSI strip (codex R5)', async () => {
+    // When `strip_ansi: false`, stripSections runs on the raw log. GitLab's
+    // section line is `section_*:NNN:name\r\x1B[0K\n` - the regex must
+    // consume the `\x1B[0K` between `\r` and `\n` so no orphan
+    // `\x1B[0K\n` fragments survive in the cleaned output.
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1:s\r\x1B[0K\n' +
+      'payload line\n' +
+      'section_end:1:s\r\x1B[0K\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, { strip_ansi: false });
+
+    // Section markers + their clear-control bytes are gone entirely
+    expect(result.log).not.toContain('section_start');
+    expect(result.log).not.toContain('section_end');
+    expect(result.log).not.toContain('\x1B[0K');
+    // Real payload preserved
+    expect(result.log).toContain('payload line');
+  });
+
+  it('tail: 1 on a single-line log with trailing newline returns the line content (codex R5)', async () => {
+    // The original logTail walked all `\n` from the end including the
+    // trailing terminator, so `tail: 1` on `"ERROR\n"` returned `""` (the
+    // slice after position 5 / end-of-string). The fix treats a single
+    // trailing `\n` as the terminator + an outer unconditional strip
+    // ensures the `log` field has a stable shape across the truncation
+    // boundary - the same tool no longer sometimes returns `"ERROR\n"`
+    // and sometimes `"ERROR"` for the same content.
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    mockJobLogResponse('ERROR\n');
+
+    const result = await api.getJobLogSmart('proj', 42, { tail: 1 });
+
+    expect(result.log).toBe('ERROR');
+    expect(result.line_count).toBe(1);
+    // Critically: log is NOT the empty string (the codex R5 regression)
+    expect(result.log).not.toBe('');
+  });
+
+  it('tail: 50 on a 50-line log returns ALL 50 lines, not 49 (codex R5)', async () => {
+    // The pre-fix bug shaved the last line off every log because the
+    // trailing `\n` was counted as a 51st empty slot.
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const lines = Array.from({ length: 50 }, (_, i) => `line-${i + 1}`);
+    const log = lines.join('\n') + '\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, { tail: 50 });
+
+    expect(result.log).toContain('line-50');
+    expect(result.log).toContain('line-1');
+    expect(result.line_count).toBe(50);
+  });
+
   it('strips section markers even when strip_ansi: false (markers are noise regardless of ANSI flag)', async () => {
     // Section stripping is decoupled from the strip_ansi flag - they're
     // independent concerns. A caller debugging raw ANSI output should still

--- a/src/gitlab-api.test.ts
+++ b/src/gitlab-api.test.ts
@@ -357,6 +357,52 @@ describe('GitLabApi.getJobLogSmart - section marker stripping (CRLF)', () => {
     expect(result.log).not.toBe('\n');
   });
 
+  it('sections_found surfaces the bare section name, not the `[collapsed=true]` suffix', async () => {
+    // GitLab `section_start:N:script[collapsed=true]\r\x1B[0K\n` discovery used
+    // to surface `script[collapsed=true]` verbatim. A caller passing that string
+    // back as the `section` arg would match the start marker (lookahead allows
+    // `[` after the name) but `section_end:N:script` would not match the
+    // start string with the brackets - the function would then read to EOF.
+    // sections_found must therefore normalize to the bare canonical name.
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1:script[collapsed=true]\r\x1B[0K\n' +
+      'running tests\n' +
+      'section_end:1:script\r\x1B[0K\n' +
+      'section_start:2:build\r\x1B[0K\n' +
+      'compiling\n' +
+      'section_end:2:build\r\x1B[0K\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, {});
+
+    expect(result.sections_found).toEqual(['script', 'build']);
+    expect(result.sections_found).not.toContain('script[collapsed=true]');
+  });
+
+  it('strips section markers even when strip_ansi: false (markers are noise regardless of ANSI flag)', async () => {
+    // Section stripping is decoupled from the strip_ansi flag - they're
+    // independent concerns. A caller debugging raw ANSI output should still
+    // get a clean tail/head window without `section_start:NNN:name\r\x1B[0K`
+    // pollution.
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1:script\r\x1B[0K\n' +
+      '\x1B[31mERROR\x1B[0m: something broke\n' +
+      'section_end:1:script\r\x1B[0K\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, { strip_ansi: false });
+
+    // Section markers are gone
+    expect(result.log).not.toContain('section_start');
+    expect(result.log).not.toContain('section_end');
+    // ANSI escapes are preserved (strip_ansi: false)
+    expect(result.log).toContain('\x1B[31m');
+    // The real payload survives
+    expect(result.log).toContain('ERROR');
+  });
+
   it('strips the entire section line even when no payload precedes section_end', async () => {
     const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
     const log =

--- a/src/gitlab-api.test.ts
+++ b/src/gitlab-api.test.ts
@@ -304,3 +304,75 @@ describe('GitLabApi.getJobLogSmart - section extraction', () => {
     expect(result.log).not.toContain('build_extra payload');
   });
 });
+
+describe('GitLabApi.getJobLogSmart - section marker stripping (CRLF)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('strips both CR and LF after the section marker - no orphan blank lines mid-log', async () => {
+    // Real GitLab: section_*:NNN:name\r\x1B[0K\n
+    // After stripAnsi → section_*:NNN:name\r\n
+    // The OLD regex `[\r\n]?` consumed only one of the two, leaving an orphan
+    // blank line where each marker used to be. The fixed `\r?\n?` regex
+    // consumes both, so the cleaned log has no spurious gaps.
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1:build\r\x1B[0K\n' +
+      'building...\n' +
+      'last real output line\n' +
+      'section_end:1:build\r\x1B[0K\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, {});
+
+    // Cleaned log must contain only the two real payload lines, separated by
+    // exactly one newline. With the bug, the result would include orphan
+    // blank lines where the section markers used to be (manifesting as
+    // sequences of `\n\n` in the output).
+    expect(result.log).not.toMatch(/\n\n/);
+    expect(result.log).toContain('building...');
+    expect(result.log).toContain('last real output line');
+  });
+
+  it('tail: 2 must return the last TWO real lines, not orphan section blanks', async () => {
+    // The orphan-`\n` bug caused tail: 2 to return a fragment like "\n" or
+    // ""/"last_line" depending on log shape. With the marker fully stripped
+    // the last 2 real lines are returned intact.
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1:build\r\x1B[0K\n' +
+      'building...\n' +
+      'last real output line\n' +
+      'section_end:1:build\r\x1B[0K\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, { tail: 2 });
+
+    // Without the fix, tail: 2 would return "\n" (two orphan newlines).
+    // With the fix, the cleaned log has structure
+    //   "building...\nlast real output line\n"
+    // so tail: 2 returns the slice after the second-to-last newline.
+    expect(result.log).toContain('last real output line');
+    expect(result.log).not.toBe('\n');
+  });
+
+  it('strips the entire section line even when no payload precedes section_end', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'first real line\n' +
+      'section_start:1:s\r\x1B[0K\n' +
+      'section_end:1:s\r\x1B[0K\n' +
+      'second real line\n';
+    mockJobLogResponse(log);
+
+    // strip_ansi defaults to true. After cleaning we should see two real
+    // lines with no orphan blanks where the markers used to be.
+    const result = await api.getJobLogSmart('proj', 42, {});
+
+    expect(result.log).toContain('first real line');
+    expect(result.log).toContain('second real line');
+    // No double newlines from orphan \n bytes
+    expect(result.log).not.toMatch(/\n\n/);
+  });
+});

--- a/src/gitlab-api.test.ts
+++ b/src/gitlab-api.test.ts
@@ -217,3 +217,90 @@ describe('GitLabApi.uploadProjectWikiAttachment (#62)', () => {
     expect(result.commit_id).toBe('abc123');
   });
 });
+
+// =============================================================================
+// getJobLogSmart - section extraction
+// =============================================================================
+
+function mockJobLogResponse(rawLog: string) {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    statusText: 'OK',
+    headers: { get: () => null },
+    text: async () => rawLog,
+  } as unknown as Awaited<ReturnType<typeof fetch>>);
+}
+
+describe('GitLabApi.getJobLogSmart - section extraction', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  // GitLab CI section markers occupy their own line - format is:
+  //   section_start:TIMESTAMP:NAME\r\x1B[0K\n
+  //   ...payload lines...\n
+  //   section_end:TIMESTAMP:NAME\r\x1B[0K\n
+  // The lookahead pin (?=[\r\n\[]|$) blocks prefix matches like requesting
+  // 'build' and silently extracting 'build_extra'.
+
+  it('does NOT match a prefix - requesting "build" must skip "build_extra"', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1700000000:build_extra\r\x1B[0K\n' +
+      'build_extra payload\n' +
+      'section_end:1700000001:build_extra\r\x1B[0K\n' +
+      'unrelated trailing line\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, { section: 'build' });
+
+    expect(result.section_matched).toBe(false);
+    expect(result.log).toBe('');
+  });
+
+  it('matches an exact section followed by CR', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1700000000:build\r\x1B[0K\n' +
+      'build step output\n' +
+      'section_end:1700000010:build\r\x1B[0K\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, { section: 'build' });
+
+    expect(result.section_matched).toBe(true);
+    expect(result.log).toContain('build step output');
+  });
+
+  it('matches an exact section whose marker carries a `[option]` collapsed marker', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1700000000:script[collapsed=true]\r\x1B[0K\n' +
+      'run the tests\n' +
+      'section_end:1700000010:script\r\x1B[0K\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, { section: 'script' });
+
+    expect(result.section_matched).toBe(true);
+    expect(result.log).toContain('run the tests');
+  });
+
+  it('picks the exact section when a prefix-shared section appears alongside it', async () => {
+    const api = new GitLabApi({ apiUrl: 'https://gitlab.example/api/v4', token: 't' });
+    const log =
+      'section_start:1700000000:build_extra\r\x1B[0K\n' +
+      'build_extra payload\n' +
+      'section_end:1700000001:build_extra\r\x1B[0K\n' +
+      'section_start:1700000002:build\r\x1B[0K\n' +
+      'the real build payload\n' +
+      'section_end:1700000003:build\r\x1B[0K\n';
+    mockJobLogResponse(log);
+
+    const result = await api.getJobLogSmart('proj', 42, { section: 'build' });
+
+    expect(result.section_matched).toBe(true);
+    expect(result.log).toContain('the real build payload');
+    expect(result.log).not.toContain('build_extra payload');
+  });
+});

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -2290,6 +2290,285 @@ export class GitLabApi {
   }
 
   // ===========================================================================
+  // CI/CD: Pipeline Investigation (composite tools)
+  // ===========================================================================
+
+  /**
+   * Fetch a pipeline summary with jobs grouped by stage and optional log tails
+   * for failed jobs. Resolves pipeline from ref or pipeline_id.
+   */
+  async getPipelineSummary(
+    projectId: string,
+    options: {
+      pipeline_id?: number;
+      ref?: string;
+      include_logs?: boolean;
+      log_lines?: number;
+      max_failed_jobs_with_logs?: number;
+    } = {}
+  ): Promise<{
+    pipeline: GitLabPipeline;
+    stages: Array<{
+      name: string;
+      status: string;
+      jobs: Array<GitLabJob & { log_tail?: string }>;
+    }>;
+    summary: {
+      total_jobs: number;
+      passed: number;
+      failed: number;
+      skipped: number;
+      manual: number;
+      canceled: number;
+      failure_pattern: string | null;
+    };
+  }> {
+    // 1. Resolve pipeline
+    let pipeline: GitLabPipeline;
+    if (options.pipeline_id) {
+      pipeline = await this.getPipeline(projectId, options.pipeline_id);
+    } else {
+      // Find latest pipeline, optionally filtered by ref
+      const listOpts: { ref?: string; per_page?: number } = { per_page: 1 };
+      if (options.ref) listOpts.ref = options.ref;
+      const result = await this.listPipelines(projectId, listOpts);
+      if (result.items.length === 0) {
+        throw new McpError(ErrorCode.InternalError, `No pipeline found${options.ref ? ` for ref '${options.ref}'` : ''}`);
+      }
+      pipeline = await this.getPipeline(projectId, result.items[0].id);
+    }
+
+    // 2. Fetch all jobs for this pipeline
+    const allJobs: GitLabJob[] = [];
+    let page = 1;
+    while (true) {
+      const batch = await this.listPipelineJobs(projectId, pipeline.id, { per_page: 100, page });
+      allJobs.push(...batch.items);
+      if (allJobs.length >= batch.count || batch.items.length < 100) break;
+      page++;
+    }
+
+    // 3. Group jobs by stage (preserve stage order from pipeline)
+    const stageOrder: string[] = [];
+    const stageMap = new Map<string, Array<GitLabJob & { log_tail?: string }>>();
+    for (const job of allJobs) {
+      if (!stageMap.has(job.stage)) {
+        stageOrder.push(job.stage);
+        stageMap.set(job.stage, []);
+      }
+      stageMap.get(job.stage)!.push(job);
+    }
+
+    // 4. Fetch log tails for failed jobs
+    const includeLogs = options.include_logs !== false;
+    const logLines = Math.min(options.log_lines || 50, 200);
+    const maxLogsToFetch = options.max_failed_jobs_with_logs || 5;
+
+    if (includeLogs) {
+      const failedJobs = allJobs.filter(j => j.status === 'failed');
+      const jobsToFetchLogs = failedJobs.slice(0, maxLogsToFetch);
+
+      await Promise.all(
+        jobsToFetchLogs.map(async (job) => {
+          try {
+            const log = await this.getJobLog(projectId, job.id);
+            const lines = log.split('\n');
+            const tail = lines.slice(-logLines).join('\n');
+            // Find the job in the stageMap and attach log_tail
+            const stageJobs = stageMap.get(job.stage);
+            const target = stageJobs?.find(j => j.id === job.id);
+            if (target) target.log_tail = tail;
+          } catch {
+            // Graceful degradation: if log fetch fails, skip it
+          }
+        })
+      );
+    }
+
+    // 5. Compute summary
+    const failed = allJobs.filter(j => j.status === 'failed');
+    const passed = allJobs.filter(j => j.status === 'success').length;
+    const skipped = allJobs.filter(j => j.status === 'skipped').length;
+    const manual = allJobs.filter(j => j.status === 'manual').length;
+    const canceled = allJobs.filter(j => j.status === 'canceled').length;
+
+    // Detect failure patterns
+    let failurePattern: string | null = null;
+    if (failed.length > 0) {
+      const reasons = failed.map(j => j.failure_reason).filter(Boolean);
+      const uniqueReasons = [...new Set(reasons)];
+      if (uniqueReasons.length === 1 && failed.length > 1) {
+        failurePattern = `All ${failed.length} failures share the same failure_reason: ${uniqueReasons[0]}`;
+      }
+    }
+
+    // 6. Build stage summaries
+    const stages = stageOrder.map(stageName => {
+      const jobs = stageMap.get(stageName)!;
+      const stageStatus = jobs.some(j => j.status === 'failed') ? 'failed' :
+        jobs.every(j => j.status === 'success') ? 'success' :
+        jobs.some(j => j.status === 'running') ? 'running' :
+        jobs.every(j => j.status === 'skipped') ? 'skipped' :
+        jobs.some(j => j.status === 'manual') ? 'manual' : 'pending';
+      return { name: stageName, status: stageStatus, jobs };
+    });
+
+    return {
+      pipeline,
+      stages,
+      summary: {
+        total_jobs: allJobs.length,
+        passed,
+        failed: failed.length,
+        skipped,
+        manual,
+        canceled,
+        failure_pattern: failurePattern,
+      }
+    };
+  }
+
+  /**
+   * Get a job's log with intelligent filtering — strip ANSI codes,
+   * section markers, timestamps, and extract relevant portions.
+   */
+  async getJobLogSmart(
+    projectId: string,
+    jobId: number,
+    options: {
+      section?: string;
+      tail?: number;
+      head?: number;
+      strip_ansi?: boolean;
+      strip_timestamps?: boolean;
+      error_only?: boolean;
+    } = {}
+  ): Promise<{
+    job_id: number;
+    log: string;
+    line_count: number;
+    truncated: boolean;
+    sections_found: string[];
+  }> {
+    const rawLog = await this.getJobLog(projectId, jobId);
+
+    const stripAnsi = options.strip_ansi !== false;
+    const stripTimestamps = options.strip_timestamps !== false;
+
+    let log = rawLog;
+
+    // Strip ANSI escape codes
+    if (stripAnsi) {
+      // eslint-disable-next-line no-control-regex
+      log = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+      // Also strip GitLab section markers
+      // eslint-disable-next-line no-control-regex
+      log = log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
+    }
+
+    // Strip GitLab timestamp prefixes (format: "2026-05-20T10:30:45.123Z " or similar)
+    if (stripTimestamps) {
+      log = log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
+    }
+
+    // Extract sections from the log
+    const sectionRegex = /section_start:\d+:([^\r\n]+)/g;
+    const sectionsFound: string[] = [];
+    let sectionMatch;
+    while ((sectionMatch = sectionRegex.exec(rawLog)) !== null) {
+      const sectionName = sectionMatch[1].replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '').trim();
+      if (sectionName && !sectionsFound.includes(sectionName)) {
+        sectionsFound.push(sectionName);
+      }
+    }
+
+    // Extract specific section if requested
+    if (options.section) {
+      const sectionStart = new RegExp(`section_start:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^\\n]*\\n?`, 'i');
+      const sectionEnd = new RegExp(`section_end:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
+      const startMatch = sectionStart.exec(rawLog);
+      if (startMatch) {
+        const startIdx = startMatch.index + startMatch[0].length;
+        const endMatch = sectionEnd.exec(rawLog.slice(startIdx));
+        const endIdx = endMatch ? startIdx + endMatch.index : rawLog.length;
+        log = rawLog.slice(startIdx, endIdx);
+        // Re-apply strip filters
+        if (stripAnsi) {
+          // eslint-disable-next-line no-control-regex
+          log = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+          // eslint-disable-next-line no-control-regex
+          log = log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
+        }
+        if (stripTimestamps) {
+          log = log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
+        }
+      }
+    }
+
+    // Error-only extraction
+    if (options.error_only) {
+      const lines = log.split('\n');
+      const errorLines = lines.filter(line => {
+        const lower = line.toLowerCase();
+        return lower.includes('error') || lower.includes('fatal') ||
+          lower.includes('failed') || lower.includes('exception') ||
+          lower.includes('traceback') || lower.includes('panic');
+      });
+      if (errorLines.length > 0) {
+        log = errorLines.join('\n');
+      }
+    }
+
+    // Apply tail/head
+    let truncated = false;
+    const lines = log.split('\n');
+    if (options.tail && options.tail < lines.length) {
+      log = lines.slice(-options.tail).join('\n');
+      truncated = true;
+    } else if (options.head && options.head < lines.length) {
+      log = lines.slice(0, options.head).join('\n');
+      truncated = true;
+    }
+
+    return {
+      job_id: jobId,
+      log,
+      line_count: log.split('\n').length,
+      truncated,
+      sections_found: sectionsFound,
+    };
+  }
+
+  /**
+   * Fetch log tails for jobs (used by list_pipeline_jobs extension).
+   * Returns a map of job_id → log tail string.
+   */
+  async getJobLogTails(
+    projectId: string,
+    jobIds: number[],
+    logLines: number = 30
+  ): Promise<Map<number, string>> {
+    const result = new Map<number, string>();
+    const cappedLines = Math.min(logLines, 200);
+
+    await Promise.all(
+      jobIds.map(async (jobId) => {
+        try {
+          const log = await this.getJobLog(projectId, jobId);
+          // eslint-disable-next-line no-control-regex
+          const cleaned = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+          const lines = cleaned.split('\n');
+          result.set(jobId, lines.slice(-cappedLines).join('\n'));
+        } catch {
+          // Graceful degradation
+        }
+      })
+    );
+
+    return result;
+  }
+
+  // ===========================================================================
   // CI/CD: Environments
   // ===========================================================================
 

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -2294,6 +2294,18 @@ export class GitLabApi {
   // ===========================================================================
 
   /**
+   * Clean a raw job log: strip ANSI codes, section markers, and timestamps.
+   */
+  private cleanLog(raw: string): string {
+    // eslint-disable-next-line no-control-regex
+    let log = raw.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+    // eslint-disable-next-line no-control-regex
+    log = log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
+    log = log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
+    return log;
+  }
+
+  /**
    * Fetch a pipeline summary with jobs grouped by stage and optional log tails
    * for failed jobs. Resolves pipeline from ref or pipeline_id.
    */
@@ -2371,8 +2383,9 @@ export class GitLabApi {
       await Promise.all(
         jobsToFetchLogs.map(async (job) => {
           try {
-            const log = await this.getJobLog(projectId, job.id);
-            const lines = log.split('\n');
+            const rawLog = await this.getJobLog(projectId, job.id);
+            const cleaned = this.cleanLog(rawLog);
+            const lines = cleaned.split('\n');
             const tail = lines.slice(-logLines).join('\n');
             // Find the job in the stageMap and attach log_tail
             const stageJobs = stageMap.get(job.stage);
@@ -2455,34 +2468,20 @@ export class GitLabApi {
     const stripAnsi = options.strip_ansi !== false;
     const stripTimestamps = options.strip_timestamps !== false;
 
-    let log = rawLog;
-
-    // Strip ANSI escape codes
-    if (stripAnsi) {
-      // eslint-disable-next-line no-control-regex
-      log = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
-      // Also strip GitLab section markers
-      // eslint-disable-next-line no-control-regex
-      log = log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
-    }
-
-    // Strip GitLab timestamp prefixes (format: "2026-05-20T10:30:45.123Z " or similar)
-    if (stripTimestamps) {
-      log = log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
-    }
-
-    // Extract sections from the log
+    // Extract sections from the raw log for discoverability, before any stripping
     const sectionRegex = /section_start:\d+:([^\r\n]+)/g;
     const sectionsFound: string[] = [];
     let sectionMatch;
     while ((sectionMatch = sectionRegex.exec(rawLog)) !== null) {
+      // eslint-disable-next-line no-control-regex
       const sectionName = sectionMatch[1].replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '').trim();
       if (sectionName && !sectionsFound.includes(sectionName)) {
         sectionsFound.push(sectionName);
       }
     }
 
-    // Extract specific section if requested
+    // Determine log content: extract specific section or use full log
+    let log = rawLog;
     if (options.section) {
       const sectionStart = new RegExp(`section_start:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^\\n]*\\n?`, 'i');
       const sectionEnd = new RegExp(`section_end:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
@@ -2492,17 +2491,18 @@ export class GitLabApi {
         const endMatch = sectionEnd.exec(rawLog.slice(startIdx));
         const endIdx = endMatch ? startIdx + endMatch.index : rawLog.length;
         log = rawLog.slice(startIdx, endIdx);
-        // Re-apply strip filters
-        if (stripAnsi) {
-          // eslint-disable-next-line no-control-regex
-          log = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
-          // eslint-disable-next-line no-control-regex
-          log = log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
-        }
-        if (stripTimestamps) {
-          log = log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
-        }
       }
+    }
+
+    // Apply stripping to the log (either full or sectioned)
+    if (stripAnsi) {
+      // eslint-disable-next-line no-control-regex
+      log = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+      // eslint-disable-next-line no-control-regex
+      log = log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
+    }
+    if (stripTimestamps) {
+      log = log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
     }
 
     // Error-only extraction
@@ -2554,9 +2554,8 @@ export class GitLabApi {
     await Promise.all(
       jobIds.map(async (jobId) => {
         try {
-          const log = await this.getJobLog(projectId, jobId);
-          // eslint-disable-next-line no-control-regex
-          const cleaned = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+          const rawLog = await this.getJobLog(projectId, jobId);
+          const cleaned = this.cleanLog(rawLog);
           const lines = cleaned.split('\n');
           result.set(jobId, lines.slice(-cappedLines).join('\n'));
         } catch {

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -131,12 +131,19 @@ export interface GitLabApiConfig {
 }
 
 /**
+ * Stage status mirrors GitLab's aggregation vocabulary.
+ */
+export type StageStatus = 'failed' | 'running' | 'pending' | 'manual' | 'skipped' | 'canceled' | 'success';
+
+/**
  * Discriminated union for pipeline failure pattern analysis.
  */
 export type FailurePattern =
+  | { kind: 'no_failures' }
+  | { kind: 'single'; reason: string | null; job_id: number }
   | { kind: 'shared_reason'; reason: string; count: number }
   | { kind: 'mixed'; reasons: Record<string, number> }
-  | { kind: 'no_failures' };
+  | { kind: 'unknown'; count: number };
 
 /**
  * Response type for get_pipeline_summary tool.
@@ -145,7 +152,7 @@ export interface PipelineSummaryResponse {
   pipeline: GitLabPipeline;
   stages: Array<{
     name: string;
-    status: string;
+    status: StageStatus;
     jobs: Array<GitLabJob & { log_tail?: string }>;
   }>;
   truncated: boolean;
@@ -156,7 +163,7 @@ export interface PipelineSummaryResponse {
     skipped: number;
     manual: number;
     canceled: number;
-    failure_pattern: FailurePattern | null;
+    failure_pattern: FailurePattern;
     log_fetch_errors?: Array<{ job_id: number; error: string }>;
   };
 }
@@ -170,8 +177,8 @@ export interface JobLogSmartResponse {
   line_count: number;
   truncated: boolean;
   sections_found: string[];
-  section_matched?: boolean;
-  error_lines_matched?: number;
+  section_matched: boolean | null;
+  error_lines_matched: number | null;
 }
 
 /**
@@ -2337,34 +2344,51 @@ export class GitLabApi {
   // CI/CD: Pipeline Investigation (composite tools)
   // ===========================================================================
 
+  /** Strip ANSI escape codes from a log string. */
+  private stripAnsi(log: string): string {
+    // eslint-disable-next-line no-control-regex
+    return log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+  }
+
+  /** Strip GitLab CI section markers from a log string. */
+  private stripSections(log: string): string {
+    // eslint-disable-next-line no-control-regex
+    return log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
+  }
+
+  /** Strip ISO timestamp prefixes from log lines. */
+  private stripTimestamps(log: string): string {
+    return log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
+  }
+
   /**
    * Clean a raw job log: strip ANSI codes, section markers, and timestamps.
    */
   private cleanLog(raw: string): string {
-    // eslint-disable-next-line no-control-regex
-    let log = raw.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
-    // eslint-disable-next-line no-control-regex
-    log = log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
-    log = log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
-    return log;
+    return this.stripTimestamps(this.stripSections(this.stripAnsi(raw)));
   }
 
   /** Discriminated union for failure pattern analysis. */
-  private analyzeFailurePattern(failedJobs: GitLabJob[]): FailurePattern | null {
+  private analyzeFailurePattern(failedJobs: GitLabJob[]): FailurePattern {
     if (failedJobs.length === 0) return { kind: 'no_failures' };
+
+    if (failedJobs.length === 1) {
+      return { kind: 'single', reason: failedJobs[0].failure_reason ?? null, job_id: failedJobs[0].id };
+    }
 
     const reasons = failedJobs.map(j => j.failure_reason).filter(Boolean) as string[];
     const uniqueReasons = [...new Set(reasons)];
 
-    if (uniqueReasons.length === 1 && failedJobs.length > 1) {
-      return { kind: 'shared_reason', reason: uniqueReasons[0], count: failedJobs.length };
+    if (reasons.length === 0) {
+      // N≥2 failed jobs where every failure_reason is missing/empty
+      return { kind: 'unknown', count: failedJobs.length };
     }
-    if (uniqueReasons.length > 1) {
-      const counts: Record<string, number> = {};
-      for (const r of reasons) counts[r] = (counts[r] || 0) + 1;
-      return { kind: 'mixed', reasons: counts };
+    if (uniqueReasons.length === 1) {
+      return { kind: 'shared_reason', reason: uniqueReasons[0], count: reasons.length };
     }
-    return null;
+    const counts: Record<string, number> = {};
+    for (const r of reasons) counts[r] = (counts[r] || 0) + 1;
+    return { kind: 'mixed', reasons: counts };
   }
 
   /**
@@ -2372,7 +2396,7 @@ export class GitLabApi {
    * - allow_failure jobs that failed don't poison the stage
    * - mixed success+skipped+canceled collapses to success
    */
-  private deriveStageStatus(jobs: GitLabJob[]): string {
+  private deriveStageStatus(jobs: GitLabJob[]): StageStatus {
     if (jobs.some(j => j.status === 'failed' && !j.allow_failure)) return 'failed';
     if (jobs.some(j => j.status === 'running')) return 'running';
     if (jobs.some(j => j.status === 'pending' || j.status === 'created')) return 'pending';
@@ -2380,6 +2404,11 @@ export class GitLabApi {
     if (jobs.every(j => j.status === 'skipped')) return 'skipped';
     if (jobs.every(j => j.status === 'canceled')) return 'canceled';
     // mixed success+skipped+canceled+allow_failure-failed all collapse to success
+    if (jobs.every(j => j.status === 'success' || j.status === 'skipped' || j.status === 'canceled' || j.allow_failure)) {
+      return 'success';
+    }
+    // Safety: log unrecognized status mix but conservatively return success
+    console.error(`[deriveStageStatus] Unrecognized job status mix: ${[...new Set(jobs.map(j => j.status))].join(',')}`);
     return 'success';
   }
 
@@ -2532,8 +2561,9 @@ export class GitLabApi {
 
     // Determine log content: extract specific section or use full log
     let log = rawLog;
-    let sectionMatched = true;
+    let sectionMatched: boolean | null = null;
     if (options.section) {
+      sectionMatched = true;
       const sectionStart = new RegExp(`section_start:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^\\n]*\\n?`, 'i');
       const sectionEnd = new RegExp(`section_end:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
       const startMatch = sectionStart.exec(rawLog);
@@ -2544,22 +2574,20 @@ export class GitLabApi {
         log = rawLog.slice(startIdx, endIdx);
       } else {
         sectionMatched = false;
+        log = ''; // don't let filters run on raw log when section was requested but not found
       }
     }
 
-    // Apply stripping (using cleanLog helper components for consistency)
+    // Apply stripping using component helpers for consistency
     if (stripAnsi) {
-      // eslint-disable-next-line no-control-regex
-      log = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
-      // eslint-disable-next-line no-control-regex
-      log = log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
+      log = this.stripSections(this.stripAnsi(log));
     }
     if (stripTimestamps) {
-      log = log.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*/gm, '');
+      log = this.stripTimestamps(log);
     }
 
     // Error-only extraction
-    let errorLinesMatched: number | undefined;
+    let errorLinesMatched: number | null = null;
     if (options.error_only) {
       const lines = log.split('\n');
       const errorLines = lines.filter(line => {
@@ -2590,7 +2618,7 @@ export class GitLabApi {
       line_count: log.split('\n').length,
       truncated,
       sections_found: sectionsFound,
-      section_matched: options.section ? sectionMatched : undefined,
+      section_matched: sectionMatched,
       error_lines_matched: errorLinesMatched,
     };
   }

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -2379,6 +2379,56 @@ export class GitLabApi {
   }
 
   /**
+   * Return the last `n` newline-delimited slices of `log` without allocating
+   * an array of all lines. Walks `\n` from the end via `lastIndexOf` so the
+   * memory footprint is O(tail) instead of O(total).
+   *
+   * Behavior matches `log.split('\n').slice(-n).join('\n')` for the cases we
+   * care about, including logs that end with a trailing `\n` (the trailing
+   * empty slice is preserved).
+   */
+  private logTail(log: string, n: number): string {
+    if (n <= 0 || log === '') return '';
+    let idx = log.length;
+    for (let i = 0; i < n; i++) {
+      const nl = log.lastIndexOf('\n', idx - 1);
+      if (nl < 0) return log; // fewer than n lines exist; return the whole log
+      idx = nl;
+    }
+    return log.slice(idx + 1);
+  }
+
+  /**
+   * Return the first `n` newline-delimited slices of `log` without allocating
+   * an array of all lines. Walks `\n` from the start via `indexOf` so the
+   * memory footprint is O(head) instead of O(total).
+   */
+  private logHead(log: string, n: number): string {
+    if (n <= 0 || log === '') return '';
+    let idx = -1;
+    for (let i = 0; i < n; i++) {
+      const nl = log.indexOf('\n', idx + 1);
+      if (nl < 0) return log; // fewer than n lines exist; return the whole log
+      idx = nl;
+    }
+    return log.slice(0, idx);
+  }
+
+  /**
+   * Count newline-delimited slices in `log` without allocating substrings.
+   * Matches `log.split('\n').length` for non-empty input; returns 0 for the
+   * empty string (where split would return [''] of length 1).
+   */
+  private countLines(log: string): number {
+    if (log === '') return 0;
+    let count = 1;
+    for (let i = 0; i < log.length; i++) {
+      if (log.charCodeAt(i) === 10 /* \n */) count++;
+    }
+    return count;
+  }
+
+  /**
    * Clean a raw job log: strip ANSI codes, section markers, and timestamps.
    */
   private cleanLog(raw: string): string {
@@ -2521,9 +2571,7 @@ export class GitLabApi {
         jobsToFetchLogs.map(async (job) => {
           try {
             const rawLog = await this.getJobLog(projectId, job.id);
-            const cleaned = this.cleanLog(rawLog);
-            const lines = cleaned.split('\n');
-            const tail = lines.slice(-logLines).join('\n');
+            const tail = this.logTail(this.cleanLog(rawLog), logLines);
             const stageJobs = stageMap.get(job.stage);
             const target = stageJobs?.find(j => j.id === job.id);
             if (target) target.log_tail = tail;
@@ -2604,13 +2652,17 @@ export class GitLabApi {
     let sectionMatched: boolean | null = null;
     if (options.section) {
       sectionMatched = true;
-      const sectionStart = new RegExp(`section_start:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^\\n]*\\n?`, 'i');
-      const sectionEnd = new RegExp(`section_end:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
+      const escapedSection = options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const sectionStart = new RegExp(`section_start:\\d+:${escapedSection}[^\\n]*\\n?`, 'i');
+      // `g` flag enables `lastIndex`-based seeking so we don't have to slice
+      // the (potentially multi-MB) rawLog before exec.
+      const sectionEnd = new RegExp(`section_end:\\d+:${escapedSection}`, 'gi');
       const startMatch = sectionStart.exec(rawLog);
       if (startMatch) {
         const startIdx = startMatch.index + startMatch[0].length;
-        const endMatch = sectionEnd.exec(rawLog.slice(startIdx));
-        const endIdx = endMatch ? startIdx + endMatch.index : rawLog.length;
+        sectionEnd.lastIndex = startIdx;
+        const endMatch = sectionEnd.exec(rawLog);
+        const endIdx = endMatch ? endMatch.index : rawLog.length;
         log = rawLog.slice(startIdx, endIdx);
       } else {
         sectionMatched = false;
@@ -2626,38 +2678,39 @@ export class GitLabApi {
       log = this.stripTimestamps(log);
     }
 
-    // Error-only extraction
+    // Error-only extraction: regex-match whole lines containing any of the
+    // error keywords. Avoids splitting the log into an array of all lines
+    // when most are non-matching.
     let errorLinesMatched: number | null = null;
     if (options.error_only) {
-      const lines = log.split('\n');
-      const errorLines = lines.filter(line => {
-        const lower = line.toLowerCase();
-        return lower.includes('error') || lower.includes('fatal') ||
-          lower.includes('failed') || lower.includes('exception') ||
-          lower.includes('traceback') || lower.includes('panic');
-      });
-      errorLinesMatched = errorLines.length;
-      // Return only matched lines; empty string if none found (not the full log)
-      log = errorLines.join('\n');
+      const errorLineRegex = /^.*(?:error|fatal|failed|exception|traceback|panic).*$/gim;
+      const matches = log.match(errorLineRegex);
+      errorLinesMatched = matches?.length ?? 0;
+      log = matches?.join('\n') ?? '';
     }
 
-    // Apply tail/head
+    // Apply tail/head via index-based helpers - O(K) memory vs the O(N)
+    // array-of-all-lines pattern. Compare against line counts in advance so
+    // we only truncate when the limit actually shrinks the log.
     let truncated = false;
-    const lines = log.split('\n');
-    if (options.tail && options.tail < lines.length) {
-      log = lines.slice(-options.tail).join('\n');
-      truncated = true;
-    } else if (options.head && options.head < lines.length) {
-      log = lines.slice(0, options.head).join('\n');
-      truncated = true;
+    if (options.tail !== undefined) {
+      const total = this.countLines(log);
+      if (options.tail < total) {
+        log = this.logTail(log, options.tail);
+        truncated = true;
+      }
+    } else if (options.head !== undefined) {
+      const total = this.countLines(log);
+      if (options.head < total) {
+        log = this.logHead(log, options.head);
+        truncated = true;
+      }
     }
 
     return {
       job_id: jobId,
       log,
-      // `''.split('\n')` returns [''] (length 1), so guard the empty-log case
-      // to report a faithful 0 instead of a misleading 1.
-      line_count: log === '' ? 0 : log.split('\n').length,
+      line_count: this.countLines(log),
       truncated,
       sections_found: sectionsFound,
       section_matched: sectionMatched,
@@ -2682,9 +2735,7 @@ export class GitLabApi {
       jobIds.map(async (jobId) => {
         try {
           const rawLog = await this.getJobLog(projectId, jobId);
-          const cleaned = this.cleanLog(rawLog);
-          const lines = cleaned.split('\n');
-          tails.set(jobId, lines.slice(-cappedLines).join('\n'));
+          tails.set(jobId, this.logTail(this.cleanLog(rawLog), cappedLines));
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
           errors.push({ job_id: jobId, error: msg });

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -2653,10 +2653,14 @@ export class GitLabApi {
     if (options.section) {
       sectionMatched = true;
       const escapedSection = options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const sectionStart = new RegExp(`section_start:\\d+:${escapedSection}[^\\n]*\\n?`, 'i');
+      // The `(?=[\\r\\n\\[]|$)` lookahead pins the section name to a delimiter
+      // (CR, LF, `[option=...]`, or end-of-string) so that a request for
+      // section `build` does NOT match an actual section named `build_extra`
+      // by prefix - per GitLab's section marker grammar.
+      const sectionStart = new RegExp(`section_start:\\d+:${escapedSection}(?=[\\r\\n\\[]|$)[^\\n]*\\n?`, 'i');
       // `g` flag enables `lastIndex`-based seeking so we don't have to slice
       // the (potentially multi-MB) rawLog before exec.
-      const sectionEnd = new RegExp(`section_end:\\d+:${escapedSection}`, 'gi');
+      const sectionEnd = new RegExp(`section_end:\\d+:${escapedSection}(?=[\\r\\n\\[]|$)`, 'gi');
       const startMatch = sectionStart.exec(rawLog);
       if (startMatch) {
         const startIdx = startMatch.index + startMatch[0].length;

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -148,7 +148,10 @@ export type StageStatus = 'failed' | 'running' | 'pending' | 'manual' | 'skipped
  *   `unreasoned_count === 0` every failure matches the diagnosis; when > 0, some
  *   failures could not be characterized.
  * - `mixed`: N≥2 failed jobs with at least two distinct `failure_reason` values.
- *   `reasons` maps each reason to its count.
+ *   `reasons` maps each reason to its count. `unreasoned_count` is the number of
+ *   failed jobs whose `failure_reason` was missing/empty and could not be
+ *   bucketed into `reasons` (≥0); `sum(reasons) + unreasoned_count` equals the
+ *   total number of failed jobs.
  * - `unknown`: N≥2 failed jobs where every `failure_reason` is missing/empty.
  *   GitLab gave us nothing to characterize; `count` is the total failure count.
  */
@@ -156,7 +159,7 @@ export type FailurePattern =
   | { kind: 'no_failures' }
   | { kind: 'single'; reason: string | null; job_id: number }
   | { kind: 'shared_reason'; reason: string; count: number; unreasoned_count: number }
-  | { kind: 'mixed'; reasons: Record<string, number> }
+  | { kind: 'mixed'; reasons: Record<string, number>; unreasoned_count: number }
   | { kind: 'unknown'; count: number };
 
 /**
@@ -2415,7 +2418,11 @@ export class GitLabApi {
     }
     const counts: Record<string, number> = {};
     for (const r of reasons) counts[r] = (counts[r] || 0) + 1;
-    return { kind: 'mixed', reasons: counts };
+    return {
+      kind: 'mixed',
+      reasons: counts,
+      unreasoned_count: failedJobs.length - reasons.length,
+    };
   }
 
   /**

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -137,11 +137,25 @@ export type StageStatus = 'failed' | 'running' | 'pending' | 'manual' | 'skipped
 
 /**
  * Discriminated union for pipeline failure pattern analysis.
+ *
+ * Variants:
+ * - `no_failures`: zero failed jobs in the pipeline.
+ * - `single`: exactly one failed job. `reason` is `null` when GitLab returned no
+ *   `failure_reason` (or an empty string). `job_id` lets the caller fetch the log.
+ * - `shared_reason`: N≥2 failed jobs that all carry the same `failure_reason`.
+ *   `count` is the number of jobs carrying the reason. `unreasoned_count` is the
+ *   number of failed jobs with no `failure_reason` populated (≥0). When
+ *   `unreasoned_count === 0` every failure matches the diagnosis; when > 0, some
+ *   failures could not be characterized.
+ * - `mixed`: N≥2 failed jobs with at least two distinct `failure_reason` values.
+ *   `reasons` maps each reason to its count.
+ * - `unknown`: N≥2 failed jobs where every `failure_reason` is missing/empty.
+ *   GitLab gave us nothing to characterize; `count` is the total failure count.
  */
 export type FailurePattern =
   | { kind: 'no_failures' }
   | { kind: 'single'; reason: string | null; job_id: number }
-  | { kind: 'shared_reason'; reason: string; count: number }
+  | { kind: 'shared_reason'; reason: string; count: number; unreasoned_count: number }
   | { kind: 'mixed'; reasons: Record<string, number> }
   | { kind: 'unknown'; count: number };
 
@@ -2368,12 +2382,20 @@ export class GitLabApi {
     return this.stripTimestamps(this.stripSections(this.stripAnsi(raw)));
   }
 
-  /** Discriminated union for failure pattern analysis. */
+  /**
+   * Analyze a set of failed jobs and return a discriminated FailurePattern.
+   * `failure_reason` values that are null, undefined, or empty string are
+   * treated as "unreasoned" - they do not contribute to the reason histogram
+   * but their count is preserved via `unreasoned_count` on shared_reason or
+   * the `unknown` variant.
+   */
   private analyzeFailurePattern(failedJobs: GitLabJob[]): FailurePattern {
     if (failedJobs.length === 0) return { kind: 'no_failures' };
 
     if (failedJobs.length === 1) {
-      return { kind: 'single', reason: failedJobs[0].failure_reason ?? null, job_id: failedJobs[0].id };
+      // Normalize empty-string failure_reason to null so the contract reads as
+      // "either we have a reason string, or we have no reason at all".
+      return { kind: 'single', reason: failedJobs[0].failure_reason || null, job_id: failedJobs[0].id };
     }
 
     const reasons = failedJobs.map(j => j.failure_reason).filter(Boolean) as string[];
@@ -2384,7 +2406,12 @@ export class GitLabApi {
       return { kind: 'unknown', count: failedJobs.length };
     }
     if (uniqueReasons.length === 1) {
-      return { kind: 'shared_reason', reason: uniqueReasons[0], count: reasons.length };
+      return {
+        kind: 'shared_reason',
+        reason: uniqueReasons[0],
+        count: reasons.length,
+        unreasoned_count: failedJobs.length - reasons.length,
+      };
     }
     const counts: Record<string, number> = {};
     for (const r of reasons) counts[r] = (counts[r] || 0) + 1;
@@ -2392,9 +2419,15 @@ export class GitLabApi {
   }
 
   /**
-   * Derive stage status from its jobs, mirroring GitLab's aggregation logic.
-   * - allow_failure jobs that failed don't poison the stage
-   * - mixed success+skipped+canceled collapses to success
+   * Derive stage status from its jobs, mirroring GitLab's aggregation logic:
+   * - `allow_failure: true` jobs that failed do NOT poison the stage to 'failed'
+   * - mixed success+skipped+canceled+allow_failure-failed all collapse to 'success'
+   * - The final safety branch is unreachable in practice when jobs are validated
+   *   by `JobStatusEnum` (closed enum at src/schemas.ts). It exists as a
+   *   schema-drift canary: if GitLab ever returns a new status value AND the
+   *   schema is relaxed to accept it, the unrecognized mix is logged via
+   *   `console.error` and the function conservatively returns 'success' rather
+   *   than throwing.
    */
   private deriveStageStatus(jobs: GitLabJob[]): StageStatus {
     if (jobs.some(j => j.status === 'failed' && !j.allow_failure)) return 'failed';
@@ -2615,7 +2648,9 @@ export class GitLabApi {
     return {
       job_id: jobId,
       log,
-      line_count: log.split('\n').length,
+      // `''.split('\n')` returns [''] (length 1), so guard the empty-log case
+      // to report a faithful 0 instead of a misleading 1.
+      line_count: log === '' ? 0 : log.split('\n').length,
       truncated,
       sections_found: sectionsFound,
       section_matched: sectionMatched,

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -131,6 +131,50 @@ export interface GitLabApiConfig {
 }
 
 /**
+ * Discriminated union for pipeline failure pattern analysis.
+ */
+export type FailurePattern =
+  | { kind: 'shared_reason'; reason: string; count: number }
+  | { kind: 'mixed'; reasons: Record<string, number> }
+  | { kind: 'no_failures' };
+
+/**
+ * Response type for get_pipeline_summary tool.
+ */
+export interface PipelineSummaryResponse {
+  pipeline: GitLabPipeline;
+  stages: Array<{
+    name: string;
+    status: string;
+    jobs: Array<GitLabJob & { log_tail?: string }>;
+  }>;
+  truncated: boolean;
+  summary: {
+    total_jobs: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    manual: number;
+    canceled: number;
+    failure_pattern: FailurePattern | null;
+    log_fetch_errors?: Array<{ job_id: number; error: string }>;
+  };
+}
+
+/**
+ * Response type for get_job_log_smart tool.
+ */
+export interface JobLogSmartResponse {
+  job_id: number;
+  log: string;
+  line_count: number;
+  truncated: boolean;
+  sections_found: string[];
+  section_matched?: boolean;
+  error_lines_matched?: number;
+}
+
+/**
  * GitLab API client for interacting with GitLab resources
  */
 export class GitLabApi {
@@ -2305,6 +2349,40 @@ export class GitLabApi {
     return log;
   }
 
+  /** Discriminated union for failure pattern analysis. */
+  private analyzeFailurePattern(failedJobs: GitLabJob[]): FailurePattern | null {
+    if (failedJobs.length === 0) return { kind: 'no_failures' };
+
+    const reasons = failedJobs.map(j => j.failure_reason).filter(Boolean) as string[];
+    const uniqueReasons = [...new Set(reasons)];
+
+    if (uniqueReasons.length === 1 && failedJobs.length > 1) {
+      return { kind: 'shared_reason', reason: uniqueReasons[0], count: failedJobs.length };
+    }
+    if (uniqueReasons.length > 1) {
+      const counts: Record<string, number> = {};
+      for (const r of reasons) counts[r] = (counts[r] || 0) + 1;
+      return { kind: 'mixed', reasons: counts };
+    }
+    return null;
+  }
+
+  /**
+   * Derive stage status from its jobs, mirroring GitLab's aggregation logic.
+   * - allow_failure jobs that failed don't poison the stage
+   * - mixed success+skipped+canceled collapses to success
+   */
+  private deriveStageStatus(jobs: GitLabJob[]): string {
+    if (jobs.some(j => j.status === 'failed' && !j.allow_failure)) return 'failed';
+    if (jobs.some(j => j.status === 'running')) return 'running';
+    if (jobs.some(j => j.status === 'pending' || j.status === 'created')) return 'pending';
+    if (jobs.some(j => j.status === 'manual')) return 'manual';
+    if (jobs.every(j => j.status === 'skipped')) return 'skipped';
+    if (jobs.every(j => j.status === 'canceled')) return 'canceled';
+    // mixed success+skipped+canceled+allow_failure-failed all collapse to success
+    return 'success';
+  }
+
   /**
    * Fetch a pipeline summary with jobs grouped by stage and optional log tails
    * for failed jobs. Resolves pipeline from ref or pipeline_id.
@@ -2315,32 +2393,15 @@ export class GitLabApi {
       pipeline_id?: number;
       ref?: string;
       include_logs?: boolean;
-      log_lines?: number;
+      log_tail_lines?: number;
       max_failed_jobs_with_logs?: number;
     } = {}
-  ): Promise<{
-    pipeline: GitLabPipeline;
-    stages: Array<{
-      name: string;
-      status: string;
-      jobs: Array<GitLabJob & { log_tail?: string }>;
-    }>;
-    summary: {
-      total_jobs: number;
-      passed: number;
-      failed: number;
-      skipped: number;
-      manual: number;
-      canceled: number;
-      failure_pattern: string | null;
-    };
-  }> {
+  ): Promise<PipelineSummaryResponse> {
     // 1. Resolve pipeline
     let pipeline: GitLabPipeline;
     if (options.pipeline_id) {
       pipeline = await this.getPipeline(projectId, options.pipeline_id);
     } else {
-      // Find latest pipeline, optionally filtered by ref
       const listOpts: { ref?: string; per_page?: number } = { per_page: 1 };
       if (options.ref) listOpts.ref = options.ref;
       const result = await this.listPipelines(projectId, listOpts);
@@ -2350,17 +2411,23 @@ export class GitLabApi {
       pipeline = await this.getPipeline(projectId, result.items[0].id);
     }
 
-    // 2. Fetch all jobs for this pipeline
+    // 2. Fetch all jobs — paginate without relying on X-Total (may be absent in EE)
+    const MAX_PAGES = 50;
     const allJobs: GitLabJob[] = [];
     let page = 1;
-    while (true) {
+    let truncated = false;
+    while (page <= MAX_PAGES) {
       const batch = await this.listPipelineJobs(projectId, pipeline.id, { per_page: 100, page });
       allJobs.push(...batch.items);
-      if (allJobs.length >= batch.count || batch.items.length < 100) break;
+      if (batch.items.length < 100) break;
       page++;
     }
+    if (page > MAX_PAGES) {
+      truncated = true;
+      console.error(`[get_pipeline_summary] Pagination cap reached (${MAX_PAGES} pages) for pipeline ${pipeline.id}`);
+    }
 
-    // 3. Group jobs by stage (preserve stage order from pipeline)
+    // 3. Group jobs by stage
     const stageOrder: string[] = [];
     const stageMap = new Map<string, Array<GitLabJob & { log_tail?: string }>>();
     for (const job of allJobs) {
@@ -2371,10 +2438,11 @@ export class GitLabApi {
       stageMap.get(job.stage)!.push(job);
     }
 
-    // 4. Fetch log tails for failed jobs
+    // 4. Fetch log tails for failed jobs (with error tracking)
     const includeLogs = options.include_logs !== false;
-    const logLines = Math.min(options.log_lines || 50, 200);
-    const maxLogsToFetch = options.max_failed_jobs_with_logs || 5;
+    const logLines = Math.min(options.log_tail_lines ?? 50, 200);
+    const maxLogsToFetch = Math.min(options.max_failed_jobs_with_logs ?? 5, 20);
+    const logFetchErrors: Array<{ job_id: number; error: string }> = [];
 
     if (includeLogs) {
       const failedJobs = allJobs.filter(j => j.status === 'failed');
@@ -2387,12 +2455,13 @@ export class GitLabApi {
             const cleaned = this.cleanLog(rawLog);
             const lines = cleaned.split('\n');
             const tail = lines.slice(-logLines).join('\n');
-            // Find the job in the stageMap and attach log_tail
             const stageJobs = stageMap.get(job.stage);
             const target = stageJobs?.find(j => j.id === job.id);
             if (target) target.log_tail = tail;
-          } catch {
-            // Graceful degradation: if log fetch fails, skip it
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logFetchErrors.push({ job_id: job.id, error: msg });
+            console.error(`[get_pipeline_summary] Failed to fetch log for job ${job.id}: ${msg}`);
           }
         })
       );
@@ -2405,30 +2474,16 @@ export class GitLabApi {
     const manual = allJobs.filter(j => j.status === 'manual').length;
     const canceled = allJobs.filter(j => j.status === 'canceled').length;
 
-    // Detect failure patterns
-    let failurePattern: string | null = null;
-    if (failed.length > 0) {
-      const reasons = failed.map(j => j.failure_reason).filter(Boolean);
-      const uniqueReasons = [...new Set(reasons)];
-      if (uniqueReasons.length === 1 && failed.length > 1) {
-        failurePattern = `All ${failed.length} failures share the same failure_reason: ${uniqueReasons[0]}`;
-      }
-    }
-
     // 6. Build stage summaries
     const stages = stageOrder.map(stageName => {
       const jobs = stageMap.get(stageName)!;
-      const stageStatus = jobs.some(j => j.status === 'failed') ? 'failed' :
-        jobs.every(j => j.status === 'success') ? 'success' :
-        jobs.some(j => j.status === 'running') ? 'running' :
-        jobs.every(j => j.status === 'skipped') ? 'skipped' :
-        jobs.some(j => j.status === 'manual') ? 'manual' : 'pending';
-      return { name: stageName, status: stageStatus, jobs };
+      return { name: stageName, status: this.deriveStageStatus(jobs), jobs };
     });
 
     return {
       pipeline,
       stages,
+      truncated,
       summary: {
         total_jobs: allJobs.length,
         passed,
@@ -2436,7 +2491,8 @@ export class GitLabApi {
         skipped,
         manual,
         canceled,
-        failure_pattern: failurePattern,
+        failure_pattern: this.analyzeFailurePattern(failed),
+        log_fetch_errors: logFetchErrors.length > 0 ? logFetchErrors : undefined,
       }
     };
   }
@@ -2456,13 +2512,7 @@ export class GitLabApi {
       strip_timestamps?: boolean;
       error_only?: boolean;
     } = {}
-  ): Promise<{
-    job_id: number;
-    log: string;
-    line_count: number;
-    truncated: boolean;
-    sections_found: string[];
-  }> {
+  ): Promise<JobLogSmartResponse> {
     const rawLog = await this.getJobLog(projectId, jobId);
 
     const stripAnsi = options.strip_ansi !== false;
@@ -2482,6 +2532,7 @@ export class GitLabApi {
 
     // Determine log content: extract specific section or use full log
     let log = rawLog;
+    let sectionMatched = true;
     if (options.section) {
       const sectionStart = new RegExp(`section_start:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^\\n]*\\n?`, 'i');
       const sectionEnd = new RegExp(`section_end:\\d+:${options.section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
@@ -2491,10 +2542,12 @@ export class GitLabApi {
         const endMatch = sectionEnd.exec(rawLog.slice(startIdx));
         const endIdx = endMatch ? startIdx + endMatch.index : rawLog.length;
         log = rawLog.slice(startIdx, endIdx);
+      } else {
+        sectionMatched = false;
       }
     }
 
-    // Apply stripping to the log (either full or sectioned)
+    // Apply stripping (using cleanLog helper components for consistency)
     if (stripAnsi) {
       // eslint-disable-next-line no-control-regex
       log = log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
@@ -2506,6 +2559,7 @@ export class GitLabApi {
     }
 
     // Error-only extraction
+    let errorLinesMatched: number | undefined;
     if (options.error_only) {
       const lines = log.split('\n');
       const errorLines = lines.filter(line => {
@@ -2514,9 +2568,9 @@ export class GitLabApi {
           lower.includes('failed') || lower.includes('exception') ||
           lower.includes('traceback') || lower.includes('panic');
       });
-      if (errorLines.length > 0) {
-        log = errorLines.join('\n');
-      }
+      errorLinesMatched = errorLines.length;
+      // Return only matched lines; empty string if none found (not the full log)
+      log = errorLines.join('\n');
     }
 
     // Apply tail/head
@@ -2536,19 +2590,22 @@ export class GitLabApi {
       line_count: log.split('\n').length,
       truncated,
       sections_found: sectionsFound,
+      section_matched: options.section ? sectionMatched : undefined,
+      error_lines_matched: errorLinesMatched,
     };
   }
 
   /**
    * Fetch log tails for jobs (used by list_pipeline_jobs extension).
-   * Returns a map of job_id → log tail string.
+   * Returns results map and any errors encountered.
    */
   async getJobLogTails(
     projectId: string,
     jobIds: number[],
     logLines: number = 30
-  ): Promise<Map<number, string>> {
-    const result = new Map<number, string>();
+  ): Promise<{ tails: Map<number, string>; errors: Array<{ job_id: number; error: string }> }> {
+    const tails = new Map<number, string>();
+    const errors: Array<{ job_id: number; error: string }> = [];
     const cappedLines = Math.min(logLines, 200);
 
     await Promise.all(
@@ -2557,14 +2614,16 @@ export class GitLabApi {
           const rawLog = await this.getJobLog(projectId, jobId);
           const cleaned = this.cleanLog(rawLog);
           const lines = cleaned.split('\n');
-          result.set(jobId, lines.slice(-cappedLines).join('\n'));
-        } catch {
-          // Graceful degradation
+          tails.set(jobId, lines.slice(-cappedLines).join('\n'));
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          errors.push({ job_id: jobId, error: msg });
+          console.error(`[getJobLogTails] Failed to fetch log for job ${jobId}: ${msg}`);
         }
       })
     );
 
-    return result;
+    return { tails, errors };
   }
 
   // ===========================================================================

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -2379,18 +2379,17 @@ export class GitLabApi {
    *
    * GitLab markers occupy their own line in the format
    *   `section_*:NNN:name\r\x1B[0K\n`
-   * Always pair this with `stripAnsi` first (e.g. via `cleanLog`). After
-   * ANSI removal the marker collapses to `section_*:NNN:name\r\n` and the
-   * `\r?\n?` tail consumes whichever CRLF combination is present (`\r\n`,
-   * `\r`, `\n`, or none), so no orphan blank line is left behind - which
-   * would otherwise shift `tail: N` extraction by one empty line per marker.
-   * If called BEFORE `stripAnsi`, the `\x1B[0K` bytes after the section
-   * name remain unconsumed; that is not a correctness problem for the
-   * current callers but is a footgun for any future direct caller.
+   * The regex tail `\r?(?:\x1B\[[0-9;]*[a-zA-Z])*\n?` consumes the optional
+   * CR, any number of inline ANSI clear-control sequences (typically the
+   * single `\x1B[0K` GitLab emits), and the trailing LF. This works whether
+   * `stripAnsi` was called first (the `\x1B[NNN]` group matches zero times)
+   * or NOT (the group consumes the orphan clear-control before the LF) -
+   * so `get_job_log_smart` with `strip_ansi: false` no longer leaks
+   * `\x1B[0K\n` fragments into the cleaned log.
    */
   private stripSections(log: string): string {
     // eslint-disable-next-line no-control-regex
-    return log.replace(/section_(start|end):\d+:[^\r\n]*\r?\n?/g, '');
+    return log.replace(/section_(start|end):\d+:[^\r\n]*\r?(?:\x1B\[[0-9;]*[a-zA-Z])*\n?/g, '');
   }
 
   /** Strip ISO timestamp prefixes from log lines. */
@@ -2399,49 +2398,56 @@ export class GitLabApi {
   }
 
   /**
-   * Return the last `n` newline-delimited slices of `log` without allocating
-   * an array of all lines. Walks `\n` from the end via `lastIndexOf` so the
-   * memory footprint is O(tail) instead of O(total).
-   *
-   * Behavior matches `log.split('\n').slice(-n).join('\n')` for the cases we
-   * care about, including logs that end with a trailing `\n` (the trailing
-   * empty slice is preserved).
+   * Return the last `n` lines of `log`. A single trailing `\n` is treated
+   * as the line terminator via the `endIdx` bound (NOT via a full
+   * `log.slice(0, -1)` copy) so the memory footprint stays O(tail) instead
+   * of the O(N) regression that allocating a normalized copy would cause.
+   * Without the bound, `tail: 1` on `"ERROR\n"` returns `""` (codex R5).
    */
   private logTail(log: string, n: number): string {
     if (n <= 0 || log === '') return '';
-    let idx = log.length;
+    const endIdx = log.endsWith('\n') ? log.length - 1 : log.length;
+    if (endIdx === 0) return '';
+    let idx = endIdx;
     for (let i = 0; i < n; i++) {
       const nl = log.lastIndexOf('\n', idx - 1);
-      if (nl < 0) return log; // fewer than n lines exist; return the whole log
+      if (nl < 0) return log.slice(0, endIdx);
       idx = nl;
     }
-    return log.slice(idx + 1);
+    return log.slice(idx + 1, endIdx);
   }
 
   /**
-   * Return the first `n` newline-delimited slices of `log` without allocating
-   * an array of all lines. Walks `\n` from the start via `indexOf` so the
-   * memory footprint is O(head) instead of O(total).
+   * Return the first `n` lines of `log`. Mirrors `logTail`: trailing `\n`
+   * is treated as terminator via `endIdx`, and the `nl >= endIdx` guard
+   * keeps a stray `\n` at position `endIdx` from being consumed as a
+   * meaningful line separator. O(head) memory via `indexOf`.
    */
   private logHead(log: string, n: number): string {
     if (n <= 0 || log === '') return '';
+    const endIdx = log.endsWith('\n') ? log.length - 1 : log.length;
+    if (endIdx === 0) return '';
     let idx = -1;
     for (let i = 0; i < n; i++) {
       const nl = log.indexOf('\n', idx + 1);
-      if (nl < 0) return log; // fewer than n lines exist; return the whole log
+      if (nl < 0 || nl >= endIdx) return log.slice(0, endIdx);
       idx = nl;
     }
     return log.slice(0, idx);
   }
 
   /**
-   * Count newline-delimited slices in `log` without allocating substrings.
-   * Matches `log.split('\n').length` for non-empty input; returns 0 for the
-   * empty string (where split would return [''] of length 1).
+   * Count meaningful lines in `log` without allocating substrings.
+   * A trailing `\n` is treated as the terminator of the last line, not as
+   * the start of a new empty line - so `"ERROR\n"` reports 1 line, matching
+   * the contract `logTail` returns. Empty string reports 0 (avoiding the
+   * `''.split('\n').length === 1` JS quirk).
    */
   private countLines(log: string): number {
     if (log === '') return 0;
-    let count = 1;
+    // Start at 0 if the log ends with '\n' (the terminator absorbs the last
+    // line slot); start at 1 otherwise (the unterminated content is one line).
+    let count = log.endsWith('\n') ? 0 : 1;
     for (let i = 0; i < log.length; i++) {
       if (log.charCodeAt(i) === 10 /* \n */) count++;
     }
@@ -2750,6 +2756,14 @@ export class GitLabApi {
         truncated = true;
       }
     }
+
+    // Drop the single trailing '\n' (if present) so the returned `log` field
+    // has a stable shape regardless of which branches ran above. Without
+    // this, tail/head truncation strips the terminator (logTail/logHead use
+    // an `endIdx` bound) while the no-truncation passthrough preserves it -
+    // an asymmetric contract where the same tool sometimes returns `"L\n"`
+    // and sometimes `"L"` for what looks like the same content via line_count.
+    if (log.endsWith('\n')) log = log.slice(0, -1);
 
     return {
       job_id: jobId,

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -2367,10 +2367,20 @@ export class GitLabApi {
     return log.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
   }
 
-  /** Strip GitLab CI section markers from a log string. */
+  /**
+   * Strip GitLab CI section markers from a log string.
+   *
+   * GitLab markers occupy their own line in the format
+   *   `section_*:NNN:name\r\x1B[0K\n`
+   * When ANSI is stripped first (the normal `cleanLog` order), the marker
+   * collapses to `section_*:NNN:name\r\n` and we need to consume BOTH CR and
+   * LF. `\r?\n?` greedily eats whichever combination is present (`\r\n`,
+   * `\r`, `\n`, or none) so no orphan blank line is left behind - which
+   * would otherwise shift `tail: N` extraction by one empty line.
+   */
   private stripSections(log: string): string {
     // eslint-disable-next-line no-control-regex
-    return log.replace(/section_(start|end):\d+:[^\r\n]*[\r\n]?/g, '');
+    return log.replace(/section_(start|end):\d+:[^\r\n]*\r?\n?/g, '');
   }
 
   /** Strip ISO timestamp prefixes from log lines. */

--- a/src/gitlab-api.ts
+++ b/src/gitlab-api.ts
@@ -182,6 +182,13 @@ export interface PipelineSummaryResponse {
     canceled: number;
     failure_pattern: FailurePattern;
     log_fetch_errors?: Array<{ job_id: number; error: string }>;
+    /**
+     * Present when `failed > max_failed_jobs_with_logs` and the helper
+     * intentionally skipped fetching logs for the trailing failures (cap
+     * default 5). `fetched` is how many had logs attached; `total_failed`
+     * is the full failure count. Absence means no cap-skipping happened.
+     */
+    log_fetch_capped?: { fetched: number; total_failed: number };
   };
 }
 
@@ -2372,11 +2379,14 @@ export class GitLabApi {
    *
    * GitLab markers occupy their own line in the format
    *   `section_*:NNN:name\r\x1B[0K\n`
-   * When ANSI is stripped first (the normal `cleanLog` order), the marker
-   * collapses to `section_*:NNN:name\r\n` and we need to consume BOTH CR and
-   * LF. `\r?\n?` greedily eats whichever combination is present (`\r\n`,
-   * `\r`, `\n`, or none) so no orphan blank line is left behind - which
-   * would otherwise shift `tail: N` extraction by one empty line.
+   * Always pair this with `stripAnsi` first (e.g. via `cleanLog`). After
+   * ANSI removal the marker collapses to `section_*:NNN:name\r\n` and the
+   * `\r?\n?` tail consumes whichever CRLF combination is present (`\r\n`,
+   * `\r`, `\n`, or none), so no orphan blank line is left behind - which
+   * would otherwise shift `tail: N` extraction by one empty line per marker.
+   * If called BEFORE `stripAnsi`, the `\x1B[0K` bytes after the section
+   * name remain unconsumed; that is not a correctness problem for the
+   * current callers but is a footgun for any future direct caller.
    */
   private stripSections(log: string): string {
     // eslint-disable-next-line no-control-regex
@@ -2462,27 +2472,24 @@ export class GitLabApi {
     }
 
     const reasons = failedJobs.map(j => j.failure_reason).filter(Boolean) as string[];
-    const uniqueReasons = [...new Set(reasons)];
+    const unreasonedCount = failedJobs.length - reasons.length;
 
     if (reasons.length === 0) {
       // N≥2 failed jobs where every failure_reason is missing/empty
       return { kind: 'unknown', count: failedJobs.length };
     }
+    const uniqueReasons = [...new Set(reasons)];
     if (uniqueReasons.length === 1) {
       return {
         kind: 'shared_reason',
         reason: uniqueReasons[0],
         count: reasons.length,
-        unreasoned_count: failedJobs.length - reasons.length,
+        unreasoned_count: unreasonedCount,
       };
     }
     const counts: Record<string, number> = {};
     for (const r of reasons) counts[r] = (counts[r] || 0) + 1;
-    return {
-      kind: 'mixed',
-      reasons: counts,
-      unreasoned_count: failedJobs.length - reasons.length,
-    };
+    return { kind: 'mixed', reasons: counts, unreasoned_count: unreasonedCount };
   }
 
   /**
@@ -2526,9 +2533,11 @@ export class GitLabApi {
       max_failed_jobs_with_logs?: number;
     } = {}
   ): Promise<PipelineSummaryResponse> {
-    // 1. Resolve pipeline
+    // 1. Resolve pipeline. Use `!== undefined` so `pipeline_id: 0` is treated
+    // as a real value (and rejected by schema's .int().positive() guard) rather
+    // than silently falling through to "find latest pipeline".
     let pipeline: GitLabPipeline;
-    if (options.pipeline_id) {
+    if (options.pipeline_id !== undefined) {
       pipeline = await this.getPipeline(projectId, options.pipeline_id);
     } else {
       const listOpts: { ref?: string; per_page?: number } = { per_page: 1 };
@@ -2567,15 +2576,21 @@ export class GitLabApi {
       stageMap.get(job.stage)!.push(job);
     }
 
-    // 4. Fetch log tails for failed jobs (with error tracking)
+    // 4. Fetch log tails for failed jobs (with error tracking + cap signal)
     const includeLogs = options.include_logs !== false;
     const logLines = Math.min(options.log_tail_lines ?? 50, 200);
     const maxLogsToFetch = Math.min(options.max_failed_jobs_with_logs ?? 5, 20);
     const logFetchErrors: Array<{ job_id: number; error: string }> = [];
+    let logFetchCapped: { fetched: number; total_failed: number } | undefined;
 
     if (includeLogs) {
       const failedJobs = allJobs.filter(j => j.status === 'failed');
       const jobsToFetchLogs = failedJobs.slice(0, maxLogsToFetch);
+      if (failedJobs.length > jobsToFetchLogs.length) {
+        // Surface the cap-skip so callers don't silently see only the first N
+        // log tails and assume that's the complete picture.
+        logFetchCapped = { fetched: jobsToFetchLogs.length, total_failed: failedJobs.length };
+      }
 
       await Promise.all(
         jobsToFetchLogs.map(async (job) => {
@@ -2620,6 +2635,7 @@ export class GitLabApi {
         canceled,
         failure_pattern: this.analyzeFailurePattern(failed),
         log_fetch_errors: logFetchErrors.length > 0 ? logFetchErrors : undefined,
+        log_fetch_capped: logFetchCapped,
       }
     };
   }
@@ -2645,13 +2661,20 @@ export class GitLabApi {
     const stripAnsi = options.strip_ansi !== false;
     const stripTimestamps = options.strip_timestamps !== false;
 
-    // Extract sections from the raw log for discoverability, before any stripping
+    // Extract sections from the raw log for discoverability, before any stripping.
+    // The captured group contains the section name + any `[option=value]` collapsed
+    // marker; we strip ANSI then drop everything from the first `[` so the surfaced
+    // name matches the literal `section_end:NNN:NAME` token that callers can pass
+    // back as the `section` argument. (End markers never carry options.)
     const sectionRegex = /section_start:\d+:([^\r\n]+)/g;
     const sectionsFound: string[] = [];
     let sectionMatch;
     while ((sectionMatch = sectionRegex.exec(rawLog)) !== null) {
-      // eslint-disable-next-line no-control-regex
-      const sectionName = sectionMatch[1].replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '').trim();
+      const sectionName = sectionMatch[1]
+        // eslint-disable-next-line no-control-regex
+        .replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '') // strip ANSI escapes
+        .replace(/\[.*$/, '')                  // strip collapsed/option suffix `[...]`
+        .trim();
       if (sectionName && !sectionsFound.includes(sectionName)) {
         sectionsFound.push(sectionName);
       }
@@ -2666,11 +2689,13 @@ export class GitLabApi {
       // The `(?=[\\r\\n\\[]|$)` lookahead pins the section name to a delimiter
       // (CR, LF, `[option=...]`, or end-of-string) so that a request for
       // section `build` does NOT match an actual section named `build_extra`
-      // by prefix - per GitLab's section marker grammar.
-      const sectionStart = new RegExp(`section_start:\\d+:${escapedSection}(?=[\\r\\n\\[]|$)[^\\n]*\\n?`, 'i');
+      // by prefix - per GitLab's section marker grammar. Matching is
+      // case-SENSITIVE: GitLab section names are identifiers and `Build` vs
+      // `build` are distinct sections - the `i` flag would create ambiguity.
+      const sectionStart = new RegExp(`section_start:\\d+:${escapedSection}(?=[\\r\\n\\[]|$)[^\\n]*\\n?`);
       // `g` flag enables `lastIndex`-based seeking so we don't have to slice
       // the (potentially multi-MB) rawLog before exec.
-      const sectionEnd = new RegExp(`section_end:\\d+:${escapedSection}(?=[\\r\\n\\[]|$)`, 'gi');
+      const sectionEnd = new RegExp(`section_end:\\d+:${escapedSection}(?=[\\r\\n\\[]|$)`, 'g');
       const startMatch = sectionStart.exec(rawLog);
       if (startMatch) {
         const startIdx = startMatch.index + startMatch[0].length;
@@ -2684,10 +2709,15 @@ export class GitLabApi {
       }
     }
 
-    // Apply stripping using component helpers for consistency
+    // Strip ANSI first if requested. Section markers are ALWAYS stripped:
+    // they're noise regardless of strip_ansi, and leaving them in would
+    // contaminate `tail`/`head` windows and inflate `line_count`. Section
+    // stripping must follow ANSI stripping because the section-marker regex
+    // expects the collapsed `\r\n` form (after the ANSI `\x1B[0K` is gone).
     if (stripAnsi) {
-      log = this.stripSections(this.stripAnsi(log));
+      log = this.stripAnsi(log);
     }
+    log = this.stripSections(log);
     if (stripTimestamps) {
       log = this.stripTimestamps(log);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ import {
   ListPipelineJobsSchema,
   GetJobSchema,
   GetJobLogSchema,
+  GetPipelineSummarySchema,
+  GetJobLogSmartSchema,
   RetryJobSchema,
   CancelJobSchema,
   ListEnvironmentsSchema,
@@ -465,7 +467,7 @@ const ALL_TOOLS = [
   // CI/CD: Jobs
   {
     name: "list_pipeline_jobs",
-    description: "List jobs for a specific pipeline",
+    description: "List jobs for a specific pipeline. Use scope=['failed'] and include_log_tail=true for quick failure investigation",
     inputSchema: createJsonSchema(ListPipelineJobsSchema),
     readOnly: true
   },
@@ -477,8 +479,20 @@ const ALL_TOOLS = [
   },
   {
     name: "get_job_log",
-    description: "Get the log/trace output of a job",
+    description: "Get the raw log/trace output of a job",
     inputSchema: createJsonSchema(GetJobLogSchema),
+    readOnly: true
+  },
+  {
+    name: "get_pipeline_summary",
+    description: "Get a complete pipeline investigation summary: pipeline details, jobs grouped by stage, and log tails for failed jobs — all in one call",
+    inputSchema: createJsonSchema(GetPipelineSummarySchema),
+    readOnly: true
+  },
+  {
+    name: "get_job_log_smart",
+    description: "Get a job's log with intelligent filtering: strip ANSI codes/timestamps, extract sections, tail/head, or error-only lines",
+    inputSchema: createJsonSchema(GetJobLogSmartSchema),
     readOnly: true
   },
   {
@@ -1384,12 +1398,41 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
           throw new Error("page must be greater than 0");
         }
 
+        if (args.log_tail_lines !== undefined && (args.log_tail_lines < 1 || args.log_tail_lines > 200)) {
+          throw new Error("log_tail_lines must be between 1 and 200");
+        }
+
         const jobs = await gitlabApi.listPipelineJobs(args.project_id, args.pipeline_id, {
           scope: args.scope,
           include_retried: args.include_retried,
           page: args.page,
           per_page: args.per_page
         });
+
+        // Extension: include log tails for failed jobs if requested
+        if (args.include_log_tail) {
+          const failedJobIds = jobs.items
+            .filter(j => j.status === 'failed')
+            .map(j => j.id);
+          if (failedJobIds.length > 0) {
+            const logTails = await gitlabApi.getJobLogTails(
+              args.project_id,
+              failedJobIds,
+              args.log_tail_lines || 30
+            );
+            const jobsWithLogs = jobs.items.map(j => ({
+              ...j,
+              ...(logTails.has(j.id) ? { log_tail: logTails.get(j.id) } : {})
+            }));
+            return {
+              content: [
+                { type: "text", text: `Found ${jobs.count} jobs (log tails included for ${logTails.size} failed jobs)` },
+                { type: "text", text: JSON.stringify(jobsWithLogs, null, 2) }
+              ]
+            };
+          }
+        }
+
         return formatJobsResponse(jobs);
       }
 
@@ -1403,6 +1446,39 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
         const args = GetJobLogSchema.parse(request.params.arguments);
         const log = await gitlabApi.getJobLog(args.project_id, args.job_id);
         return { content: [{ type: "text", text: log }] };
+      }
+
+      case "get_pipeline_summary": {
+        const args = GetPipelineSummarySchema.parse(request.params.arguments);
+
+        if (args.log_lines !== undefined && (args.log_lines < 1 || args.log_lines > 200)) {
+          throw new Error("log_lines must be between 1 and 200");
+        }
+
+        const summary = await gitlabApi.getPipelineSummary(args.project_id, {
+          pipeline_id: args.pipeline_id,
+          ref: args.ref,
+          include_logs: args.include_logs,
+          log_lines: args.log_lines,
+          max_failed_jobs_with_logs: args.max_failed_jobs_with_logs,
+        });
+
+        return { content: [{ type: "text", text: JSON.stringify(summary, null, 2) }] };
+      }
+
+      case "get_job_log_smart": {
+        const args = GetJobLogSmartSchema.parse(request.params.arguments);
+
+        const result = await gitlabApi.getJobLogSmart(args.project_id, args.job_id, {
+          section: args.section,
+          tail: args.tail,
+          head: args.head,
+          strip_ansi: args.strip_ansi,
+          strip_timestamps: args.strip_timestamps,
+          error_only: args.error_only,
+        });
+
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "retry_job": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1422,12 +1422,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
               ...j,
               ...(tails.has(j.id) ? { log_tail: tails.get(j.id) } : {})
             }));
-            const errorSuffix = errors.length > 0 ? `, ${errors.length} log fetch failed` : '';
+            const errorSuffix = errors.length > 0 ? `, ${errors.length} failed` : '';
             return {
               content: [
                 { type: "text", text: `Found ${jobs.count} jobs (log tails: ${tails.size} success${errorSuffix})` },
-                { type: "text", text: JSON.stringify(jobsWithLogs, null, 2) },
-                ...(errors.length > 0 ? [{ type: "text" as const, text: JSON.stringify({ log_fetch_errors: errors }, null, 2) }] : [])
+                { type: "text", text: JSON.stringify({
+                  jobs: jobsWithLogs,
+                  ...(errors.length > 0 ? { log_fetch_errors: errors } : {})
+                }, null, 2) }
               ]
             };
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1405,34 +1405,42 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
           per_page: args.per_page
         });
 
-        // Extension: include log tails for failed jobs if requested
+        // Extension: include log tails for failed jobs if requested.
+        // When include_log_tail is true, response shape is ALWAYS the unified
+        // wrapper { jobs, log_fetch_errors? } so consumers can rely on a stable
+        // contract regardless of whether the pipeline had failed jobs or whether
+        // log fetches succeeded.
         if (args.include_log_tail) {
           const failedJobIds = jobs.items
             .filter(j => j.status === 'failed')
             .map(j => j.id);
           const maxJobs = Math.min(args.max_log_tail_jobs ?? 10, 20);
           const slicedIds = failedJobIds.slice(0, maxJobs);
+          let tails = new Map<number, string>();
+          let errors: Array<{ job_id: number; error: string }> = [];
           if (slicedIds.length > 0) {
-            const { tails, errors } = await gitlabApi.getJobLogTails(
+            const result = await gitlabApi.getJobLogTails(
               args.project_id,
               slicedIds,
               args.log_tail_lines ?? 30
             );
-            const jobsWithLogs = jobs.items.map(j => ({
-              ...j,
-              ...(tails.has(j.id) ? { log_tail: tails.get(j.id) } : {})
-            }));
-            const errorSuffix = errors.length > 0 ? `, ${errors.length} failed` : '';
-            return {
-              content: [
-                { type: "text", text: `Found ${jobs.count} jobs (log tails: ${tails.size} success${errorSuffix})` },
-                { type: "text", text: JSON.stringify({
-                  jobs: jobsWithLogs,
-                  ...(errors.length > 0 ? { log_fetch_errors: errors } : {})
-                }, null, 2) }
-              ]
-            };
+            tails = result.tails;
+            errors = result.errors;
           }
+          const jobsWithLogs = jobs.items.map(j => ({
+            ...j,
+            ...(tails.has(j.id) ? { log_tail: tails.get(j.id) } : {})
+          }));
+          const errorSuffix = errors.length > 0 ? `, ${errors.length} failed` : '';
+          return {
+            content: [
+              { type: "text", text: `Found ${jobs.count} jobs (log tails: ${tails.size} success${errorSuffix})` },
+              { type: "text", text: JSON.stringify({
+                jobs: jobsWithLogs,
+                ...(errors.length > 0 ? { log_fetch_errors: errors } : {})
+              }, null, 2) }
+            ]
+          };
         }
 
         return formatJobsResponse(jobs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1407,9 +1407,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
         // Extension: include log tails for failed jobs if requested.
         // When include_log_tail is true, response shape is ALWAYS the unified
-        // wrapper { jobs, log_fetch_errors? } so consumers can rely on a stable
-        // contract regardless of whether the pipeline had failed jobs or whether
-        // log fetches succeeded.
+        // wrapper { jobs, log_fetch_errors?, log_fetch_capped? } so consumers
+        // can rely on a stable contract regardless of whether the pipeline
+        // had failed jobs or whether log fetches succeeded.
         if (args.include_log_tail) {
           const failedJobIds = jobs.items
             .filter(j => j.status === 'failed')
@@ -1431,13 +1431,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
             ...j,
             ...(tails.has(j.id) ? { log_tail: tails.get(j.id) } : {})
           }));
+          // Cap signal: when failed jobs exceed max_log_tail_jobs, surface it
+          // so the caller knows trailing failures are missing their log_tail.
+          const capped = failedJobIds.length > slicedIds.length
+            ? { fetched: slicedIds.length, total_failed: failedJobIds.length }
+            : undefined;
           const errorSuffix = errors.length > 0 ? `, ${errors.length} failed` : '';
+          const cappedSuffix = capped ? `, capped at ${capped.fetched}/${capped.total_failed} failed` : '';
           return {
             content: [
-              { type: "text", text: `Found ${jobs.count} jobs (log tails: ${tails.size} success${errorSuffix})` },
+              { type: "text", text: `Found ${jobs.count} jobs (log tails: ${tails.size} success${errorSuffix}${cappedSuffix})` },
               { type: "text", text: JSON.stringify({
                 jobs: jobsWithLogs,
-                ...(errors.length > 0 ? { log_fetch_errors: errors } : {})
+                ...(errors.length > 0 ? { log_fetch_errors: errors } : {}),
+                ...(capped ? { log_fetch_capped: capped } : {})
               }, null, 2) }
             ]
           };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1398,10 +1398,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
           throw new Error("page must be greater than 0");
         }
 
-        if (args.log_tail_lines !== undefined && (args.log_tail_lines < 1 || args.log_tail_lines > 200)) {
-          throw new Error("log_tail_lines must be between 1 and 200");
-        }
-
         const jobs = await gitlabApi.listPipelineJobs(args.project_id, args.pipeline_id, {
           scope: args.scope,
           include_retried: args.include_retried,
@@ -1414,20 +1410,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
           const failedJobIds = jobs.items
             .filter(j => j.status === 'failed')
             .map(j => j.id);
-          if (failedJobIds.length > 0) {
-            const logTails = await gitlabApi.getJobLogTails(
+          const maxJobs = Math.min(args.max_log_tail_jobs ?? 10, 20);
+          const slicedIds = failedJobIds.slice(0, maxJobs);
+          if (slicedIds.length > 0) {
+            const { tails, errors } = await gitlabApi.getJobLogTails(
               args.project_id,
-              failedJobIds,
-              args.log_tail_lines || 30
+              slicedIds,
+              args.log_tail_lines ?? 30
             );
             const jobsWithLogs = jobs.items.map(j => ({
               ...j,
-              ...(logTails.has(j.id) ? { log_tail: logTails.get(j.id) } : {})
+              ...(tails.has(j.id) ? { log_tail: tails.get(j.id) } : {})
             }));
+            const errorSuffix = errors.length > 0 ? `, ${errors.length} log fetch failed` : '';
             return {
               content: [
-                { type: "text", text: `Found ${jobs.count} jobs (log tails included for ${logTails.size} failed jobs)` },
-                { type: "text", text: JSON.stringify(jobsWithLogs, null, 2) }
+                { type: "text", text: `Found ${jobs.count} jobs (log tails: ${tails.size} success${errorSuffix})` },
+                { type: "text", text: JSON.stringify(jobsWithLogs, null, 2) },
+                ...(errors.length > 0 ? [{ type: "text" as const, text: JSON.stringify({ log_fetch_errors: errors }, null, 2) }] : [])
               ]
             };
           }
@@ -1451,15 +1451,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
       case "get_pipeline_summary": {
         const args = GetPipelineSummarySchema.parse(request.params.arguments);
 
-        if (args.log_lines !== undefined && (args.log_lines < 1 || args.log_lines > 200)) {
-          throw new Error("log_lines must be between 1 and 200");
-        }
-
         const summary = await gitlabApi.getPipelineSummary(args.project_id, {
           pipeline_id: args.pipeline_id,
           ref: args.ref,
           include_logs: args.include_logs,
-          log_lines: args.log_lines,
+          log_tail_lines: args.log_tail_lines,
           max_failed_jobs_with_logs: args.max_failed_jobs_with_logs,
         });
 

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -403,4 +403,55 @@ describe('Response schemas — GitLab EE nullability', () => {
       expect(parsed.avatar_url).toBeNull();
     });
   });
+
+  describe('Pipeline investigation schemas - input hardening', () => {
+    it('GetPipelineSummarySchema rejects pipeline_id: 0 (silent-failure guard)', async () => {
+      const { GetPipelineSummarySchema } = await import('./schemas.js');
+      const result = GetPipelineSummarySchema.safeParse({ project_id: 'p', pipeline_id: 0 });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // Must mention positive constraint (zod's default error includes "Number must be greater than 0")
+        const msg = result.error.issues.map(i => i.message).join(' ');
+        expect(msg.toLowerCase()).toMatch(/positive|greater than 0/);
+      }
+    });
+
+    it('GetPipelineSummarySchema rejects negative pipeline_id', async () => {
+      const { GetPipelineSummarySchema } = await import('./schemas.js');
+      const result = GetPipelineSummarySchema.safeParse({ project_id: 'p', pipeline_id: -1 });
+      expect(result.success).toBe(false);
+    });
+
+    it('GetPipelineSummarySchema accepts a positive pipeline_id', async () => {
+      const { GetPipelineSummarySchema } = await import('./schemas.js');
+      const result = GetPipelineSummarySchema.safeParse({ project_id: 'p', pipeline_id: 42 });
+      expect(result.success).toBe(true);
+    });
+
+    it('GetJobLogSmartSchema rejects empty section string (silent-skip guard)', async () => {
+      const { GetJobLogSmartSchema } = await import('./schemas.js');
+      const result = GetJobLogSmartSchema.safeParse({ project_id: 'p', job_id: 1, section: '' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const paths = result.error.issues.flatMap(i => i.path);
+        expect(paths).toContain('section');
+      }
+    });
+
+    it('GetJobLogSmartSchema rejects job_id: 0', async () => {
+      const { GetJobLogSmartSchema } = await import('./schemas.js');
+      const result = GetJobLogSmartSchema.safeParse({ project_id: 'p', job_id: 0 });
+      expect(result.success).toBe(false);
+    });
+
+    it('GetJobLogSmartSchema accepts a positive job_id and non-empty section', async () => {
+      const { GetJobLogSmartSchema } = await import('./schemas.js');
+      const result = GetJobLogSmartSchema.safeParse({
+        project_id: 'p',
+        job_id: 42,
+        section: 'build',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -950,6 +950,8 @@ export const ListPipelineJobsSchema = z.object({
   pipeline_id: z.number().describe("Pipeline ID"),
   scope: z.array(JobStatusEnum).optional().describe("Filter by job status"),
   include_retried: z.boolean().optional().describe("Include retried jobs"),
+  include_log_tail: z.boolean().optional().describe("Include last N lines of each failed job's log in the response"),
+  log_tail_lines: z.number().optional().describe("Number of log lines to include per failed job (default: 30, max: 200)"),
   page: z.number().optional().describe("Page number (1-indexed)"),
   per_page: z.number().optional().describe("Results per page (1-100)"),
 });
@@ -972,6 +974,27 @@ export const RetryJobSchema = z.object({
 export const CancelJobSchema = z.object({
   project_id: z.string().describe("Project ID or URL-encoded path"),
   job_id: z.number().describe("Job ID"),
+});
+
+// Pipeline Investigation Tool Schemas
+export const GetPipelineSummarySchema = z.object({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
+  pipeline_id: z.number().optional().describe("Specific pipeline ID. If omitted, uses latest pipeline"),
+  ref: z.string().optional().describe("Branch or tag to find pipeline (alternative to pipeline_id)"),
+  include_logs: z.boolean().optional().describe("Include tail of failed job logs (default: true)"),
+  log_lines: z.number().optional().describe("Number of log tail lines per failed job (default: 50, max: 200)"),
+  max_failed_jobs_with_logs: z.number().optional().describe("Maximum number of failed jobs to fetch logs for (default: 5)"),
+});
+
+export const GetJobLogSmartSchema = z.object({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
+  job_id: z.number().describe("Job ID"),
+  section: z.string().optional().describe("Extract specific log section (e.g. 'script', 'after_script')"),
+  tail: z.number().optional().describe("Return only last N lines"),
+  head: z.number().optional().describe("Return only first N lines"),
+  strip_ansi: z.boolean().optional().describe("Remove ANSI escape codes (default: true)"),
+  strip_timestamps: z.boolean().optional().describe("Remove GitLab timestamp prefixes (default: true)"),
+  error_only: z.boolean().optional().describe("Attempt to extract only error-related lines (default: false)"),
 });
 
 // Environment Tool Schemas

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -980,7 +980,7 @@ export const CancelJobSchema = z.object({
 // Pipeline Investigation Tool Schemas
 export const GetPipelineSummarySchema = z.object({
   project_id: z.string().describe("Project ID or URL-encoded path"),
-  pipeline_id: z.number().optional().describe("Specific pipeline ID. If omitted, uses latest pipeline"),
+  pipeline_id: z.number().int().positive().optional().describe("Specific pipeline ID. If omitted, uses latest pipeline"),
   ref: z.string().optional().describe("Branch or tag to find pipeline (alternative to pipeline_id)"),
   include_logs: z.boolean().optional().describe("Include tail of failed job logs (default: true)"),
   log_tail_lines: z.number().int().min(1).max(200).optional().describe("Number of log tail lines per failed job (default: 50, max: 200)"),
@@ -991,13 +991,13 @@ export const GetPipelineSummarySchema = z.object({
 
 export const GetJobLogSmartSchema = z.object({
   project_id: z.string().describe("Project ID or URL-encoded path"),
-  job_id: z.number().describe("Job ID"),
-  section: z.string().optional().describe("Extract specific log section (e.g. 'script', 'after_script')"),
+  job_id: z.number().int().positive().describe("Job ID"),
+  section: z.string().min(1).optional().describe("Extract specific log section (e.g. 'script', 'after_script'). Case-sensitive exact match against GitLab section names."),
   tail: z.number().int().min(1).optional().describe("Return only last N lines"),
   head: z.number().int().min(1).optional().describe("Return only first N lines"),
-  strip_ansi: z.boolean().optional().describe("Remove ANSI escape codes (default: true)"),
+  strip_ansi: z.boolean().optional().describe("Remove ANSI escape codes (default: true). Section markers are always stripped regardless of this flag - they would otherwise pollute tail/head windows."),
   strip_timestamps: z.boolean().optional().describe("Remove GitLab timestamp prefixes (default: true)"),
-  error_only: z.boolean().optional().describe("Extract only error-related lines; returns empty log with error_lines_matched=0 if none found (default: false)"),
+  error_only: z.boolean().optional().describe("Extract only error-related lines (English keywords: error/fatal/failed/exception/traceback/panic). Returns empty log with error_lines_matched=0 if none found (default: false)."),
 }).refine(v => !(v.tail !== undefined && v.head !== undefined), {
   message: "Pass either tail or head, not both",
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -951,7 +951,8 @@ export const ListPipelineJobsSchema = z.object({
   scope: z.array(JobStatusEnum).optional().describe("Filter by job status"),
   include_retried: z.boolean().optional().describe("Include retried jobs"),
   include_log_tail: z.boolean().optional().describe("Include last N lines of each failed job's log in the response"),
-  log_tail_lines: z.number().optional().describe("Number of log lines to include per failed job (default: 30, max: 200)"),
+  log_tail_lines: z.number().int().min(1).max(200).optional().describe("Number of log lines to include per failed job (default: 30, max: 200)"),
+  max_log_tail_jobs: z.number().int().min(1).max(20).optional().describe("Maximum number of failed jobs to fetch logs for (default: 10, max: 20)"),
   page: z.number().optional().describe("Page number (1-indexed)"),
   per_page: z.number().optional().describe("Results per page (1-100)"),
 });
@@ -982,19 +983,23 @@ export const GetPipelineSummarySchema = z.object({
   pipeline_id: z.number().optional().describe("Specific pipeline ID. If omitted, uses latest pipeline"),
   ref: z.string().optional().describe("Branch or tag to find pipeline (alternative to pipeline_id)"),
   include_logs: z.boolean().optional().describe("Include tail of failed job logs (default: true)"),
-  log_lines: z.number().optional().describe("Number of log tail lines per failed job (default: 50, max: 200)"),
-  max_failed_jobs_with_logs: z.number().optional().describe("Maximum number of failed jobs to fetch logs for (default: 5)"),
+  log_tail_lines: z.number().int().min(1).max(200).optional().describe("Number of log tail lines per failed job (default: 50, max: 200)"),
+  max_failed_jobs_with_logs: z.number().int().min(0).max(20).optional().describe("Maximum number of failed jobs to fetch logs for (default: 5, max: 20)"),
+}).refine(v => !(v.pipeline_id !== undefined && v.ref !== undefined), {
+  message: "Pass either pipeline_id or ref, not both",
 });
 
 export const GetJobLogSmartSchema = z.object({
   project_id: z.string().describe("Project ID or URL-encoded path"),
   job_id: z.number().describe("Job ID"),
   section: z.string().optional().describe("Extract specific log section (e.g. 'script', 'after_script')"),
-  tail: z.number().optional().describe("Return only last N lines"),
-  head: z.number().optional().describe("Return only first N lines"),
+  tail: z.number().int().min(1).optional().describe("Return only last N lines"),
+  head: z.number().int().min(1).optional().describe("Return only first N lines"),
   strip_ansi: z.boolean().optional().describe("Remove ANSI escape codes (default: true)"),
   strip_timestamps: z.boolean().optional().describe("Remove GitLab timestamp prefixes (default: true)"),
-  error_only: z.boolean().optional().describe("Attempt to extract only error-related lines (default: false)"),
+  error_only: z.boolean().optional().describe("Extract only error-related lines; returns empty log with error_lines_matched=0 if none found (default: false)"),
+}).refine(v => !(v.tail !== undefined && v.head !== undefined), {
+  message: "Pass either tail or head, not both",
 });
 
 // Environment Tool Schemas


### PR DESCRIPTION
## Path B reincarnation of #86

This PR supersedes #86 with the maintainer's round-3 follow-up fixes applied directly. Per [CONTRIBUTING.md § "Maintainer rebase pattern (Path B)"](../blob/main/CONTRIBUTING.md), the contributor's authorship on the original four commits is preserved via `git cherry-pick -x`. The remaining contract gaps identified in the round-3 review are landed as three maintainer commits on top of the contributor's work.

Closes #64. Supersedes #86 (preserved as the design+iteration audit trail).

## Contributor credit (4 commits, authorship preserved)

@ecthelion77 / Olivier Gintrand `<olivier.gintrand@forterro.com>`:

- `feat: add pipeline investigation tools (closes #64)` - initial implementation of `get_pipeline_summary`, `get_job_log_smart`, `list_pipeline_jobs + include_log_tail` extension per the agreed design from #64.
- `refactor: address Gemini Code Assist review feedback` - pulled `cleanLog()` out as a helper after the first automated review pass.
- `fix: address PR #86 review - bounded fan-out, error surfacing, pagination safety` - round-2: 11/12 items closed-as-described, plus unprompted helper extraction (`analyzeFailurePattern`, `deriveStageStatus`) and exported types (`FailurePattern`, `PipelineSummaryResponse`, `JobLogSmartResponse`).
- `fix: address PR #86 round-3 residuals - type safety, contract clarity` - round-3: 4 of 5 contract-clarity items closed-as-described.

The convergent three-reviewer audit (code-quality + silent-failure + type-design) moved the type-design rating from 2/5 → 4/5 → 4.6/5 across the three rounds. This is genuinely high-craft work; the reincarnation is for the maintainer to close two residual gaps that didn't make the contributor's last push, not a rewrite of the contribution.

## Maintainer round-3 follow-up (3 commits)

**`fix(pipeline-tools): close round-3 review residuals`** (`src/index.ts`, `src/gitlab-api.ts`):
1. **`list_pipeline_jobs (include_log_tail=true)` wrapper consistency.** The unified `{jobs, log_fetch_errors?}` response shape now applies on every path, including the previously-overlooked zero-failed-jobs fallback where `formatJobsResponse(jobs)` reverted the response to the legacy flat-array shape. This was the only PARTIAL item from the round-3 verification.
2. **`FailurePattern.shared_reason` gains `unreasoned_count`.** Convergent MEDIUM finding from the round-3 audit: when some failed jobs lack `failure_reason` (filtered out by `.filter(Boolean)`), the previous `count` understated the diagnosis scope without signal. `unreasoned_count = failedJobs.length - reasons.length` makes the gap explicit; `count === unreasoned_count + reasons.length` always.
3. **`FailurePattern.single.reason` normalization.** Empty-string `failure_reason` from GitLab now collapses to `null` via `||` rather than passing through `??` verbatim. Aligns with the `.filter(Boolean)` semantics in the multi-job branches.
4. **`get_job_log_smart.line_count` empty-log faithfulness.** `''.split('\n').length === 1` is a JS quirk; the response now reports `0` when `log === ''` (a path that became reachable in round 3 when `section`-not-found started returning empty log).

**`test(e2e): tighten pipelines assertions for round-3 contract fixes`** (`e2e/src/tests/pipelines.e2e.ts`):
- Replaces the single `expect(text.length).toBeGreaterThan(0)` smoke for `list_pipeline_jobs + include_log_tail` with two structured tests that parse the JSON wrapper and assert the contract on BOTH paths (failed-jobs-exist and zero-failed-jobs-fallback). The latter is a regression test for the fix above.

**`docs(changelog): record round-3 follow-up fixes for 0.9.0`** (`CHANGELOG.md`):
- Updates the `failure_pattern` entry to list all five variants and document `unreasoned_count`.
- Adds three Fixed entries for the round-3 follow-up items.

## Deferred to 0.9.1 (explicit in the round-3 review comment)

These were named as deferred at https://github.com/yoda-digital/mcp-gitlab-server/pull/86#issuecomment-4534477857 and are NOT addressed here:
- `truncated=true` false-positive at the exact 5000-job pagination boundary
- `page`/`per_page` still bare `z.number()` on `ListPipelineJobsSchema` (other numeric fields use `.int().min().max()`)
- `max_failed_jobs_with_logs: 0` as a second-channel disable path alongside `include_logs: false`
- Pure type-design aesthetic refactors (`StageStatus = Exclude<JobStatus, 'created'>`, `StageStatus` z.enum companion)

## Test coverage

- Unit tests: 86/86 pass (`npm test`)
- Coverage gate: PASS (88/88 tools have at least one test)
- TypeScript: clean (`npm run build`)
- E2E: triggered via `[e2e]` flag on the test commit; runs against a real GitLab CE in CI

## Merge plan

Per `feedback-pr-merge-strategy-preserve-vs-squash`: this is a multi-commit substantive PR - use `--merge` to preserve the audit trail (4 contributor commits + 3 maintainer commits on main). Squash would discard the contributor authorship + round-by-round history that makes this PR legible six months from now.

After merge: 0.9.0 release per the release-driven publish pattern.
