### PR TITLE
chore(release): 0.9.0 - pipeline investigation tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet. New entries land here between releases._
+
+## [0.9.0] - 2026-05-27
+
+Pipeline investigation tools - three new MCP surfaces (`get_pipeline_summary`, `get_job_log_smart`, `list_pipeline_jobs` extension) for AI-agent-friendly CI failure investigation. Closes #64 (the reincarnation arc through #86 → #99). Substantial review cycle: 3 contributor rounds + 1 maintainer Path-B reincarnation + 5 codex bot review rounds + 2 pre-push agent passes closed 21 real bugs end-to-end.
+
+Contributors: @ecthelion77 (Olivier Gintrand) authored the original three-tool design + initial implementation + three response rounds; maintainer added contract-clarity / silent-failure / perf hardening on top via Path B reincarnation (#99).
+
 ### Added
 
 - **`get_pipeline_summary` tool** — single-call pipeline investigation returning

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Release 0.9.0 - Pipeline Investigation Tools

Three new MCP tools for AI-agent-friendly CI failure investigation. Closes #64.

## What's in 0.9.0

### New tools

- **`get_pipeline_summary`** - single-call pipeline aggregator (pipeline + jobs grouped by stage + log tails for failed jobs). Includes failure-pattern detection (`shared_reason | mixed | unknown | single | no_failures`), `truncated` and `log_fetch_capped` signal fields, and a `max_failed_jobs_with_logs` cap (default 5) to prevent context blowup.
- **`get_job_log_smart`** - intelligent log post-processor. Strips ANSI codes, GitLab CI section markers, and timestamps. Supports `section` extraction (exact-match, case-sensitive), `tail`/`head` (O(K) memory), and `error_only` filtering (single `gim` regex match). Returns explicit `section_matched` / `error_lines_matched` signals (never silently falls back).
- **`list_pipeline_jobs + include_log_tail` extension** - new optional `include_log_tail` / `log_tail_lines` / `max_log_tail_jobs` parameters. When `include_log_tail=true`, the response shape is ALWAYS the unified `{jobs, log_fetch_errors?, log_fetch_capped?}` wrapper (stable contract across the truncation boundary).

### Contributor

@ecthelion77 (Olivier Gintrand) authored the original three-tool design through three structured rounds of review (#86). Maintainer added contract-clarity, silent-failure-hunter, and perf hardening on top via Path B reincarnation (#99). All four contributor commits land on `main` with authorship preserved via `git cherry-pick -x`.

### Review cycle

End-to-end: 21 real bugs caught and closed.

- 5 codex P2 rounds (mixed.unreasoned_count parity, section prefix-match, stripSections CRLF, sections_found collapsed-marker, logTail trailing-newline + stripSections clear-control)
- 5 gemini perf MEDIUM (5 O(N)→O(K) log split-slice-join sites converted to `lastIndexOf`/`indexOf`/`charCodeAt` helpers)
- 11 pre-push agent findings (silent-failure-hunter HIGH `pipeline_id` truthy, log_fetch_capped signal x2, section empty + 3 MEDIUM + 2 LOW; code-simplifier 3 actionable)

## Release checklist

- [x] `package.json` 0.8.1 → 0.9.0
- [x] `package-lock.json` regenerated
- [x] CHANGELOG `[Unreleased]` block dated `[0.9.0] - 2026-05-27`
- [x] Build clean (`tsc`)
- [x] 104/104 unit tests pass (`vitest run`)
- [x] All previous review rounds closed in `main` via #99

## Merge plan

Single-commit ceremony PR - **squash merge** per repo convention. After merge:
1. Tag `v0.9.0` on the squash commit
2. Create GitHub Release on the tag → triggers `publish.yml` on `release.published` → npm + ghcr + helm + cosign attest + Trivy
