### PR TITLE
chore(release): 0.9.1 - Dependency hygiene + E2E timing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet. New entries land here between releases._
 
+## [0.9.1] - 2026-05-27
+
+Dependency hygiene chore release - 8 Dependabot bumps batched together plus one E2E test resilience fix surfaced by the batch's timing shift. Zero MCP source-code changes; this is purely infra + test hardening on top of 0.9.0.
+
+### Changed
+
+- **`qs`** 6.14.2 → 6.15.2 (transitive npm patch) (#87)
+- **`node`** Docker base image digest `e71ac5e...` → `7c6af15...` (#88)
+- **`vitest`** dev dependency 4.1.6 → 4.1.7 (patch) (#94)
+- **`docker/setup-buildx-action`** GH Action 4.0.0 → 4.1.0 (minor) (#89)
+- **`actions/checkout`** GH Action 4 → 6 (MAJOR, Node 24 runtime per upstream v5/v6 - ubuntu-latest runner v2.327.1+ satisfies the requirement) (#90)
+- **`docker/build-push-action`** GH Action 6.19.2 → 7.2.0 (MAJOR, Node 24 runtime; drops deprecated `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs - confirmed not used in this repo) (#91)
+- **`docker/login-action`** GH Action 3 → 4 (MAJOR) (#92)
+- **`docker/setup-qemu-action`** GH Action 3.7.0 → 4.0.0 (MAJOR) (#93)
+
+All 4 MAJOR GH Action bumps verified via upstream changelog review; SHA-pins on the OIDC-scoped `docker` job updated by Dependabot itself in each PR.
+
+### Fixed
+
+- **E2E `get_job_log_smart — returns cleaned log output`** test no longer fails on a borderline-empty trace. The GitLab CE job runner sometimes hasn't flushed output yet at the test's 3-second wait window; the assertion `line_count > 0` flipped from intermittently-passing to consistently-failing after the Node digest bump (#88) shifted timing by ~50-100ms. Fix: when the call succeeds but returns `line_count: 0`, skip the content assertions with a `console.warn` - mirroring the existing 404 "trace not available" catch in the same test. Shape correctness is still asserted when the trace IS populated. (#101)
+
 ## [0.9.0] - 2026-05-27
 
 Pipeline investigation tools - three new MCP surfaces (`get_pipeline_summary`, `get_job_log_smart`, `list_pipeline_jobs` extension) for AI-agent-friendly CI failure investigation. Closes #64 (the reincarnation arc through #86 → #99). Substantial review cycle: 3 contributor rounds + 1 maintainer Path-B reincarnation + 5 codex bot review rounds + 2 pre-push agent passes closed 21 real bugs end-to-end.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoda.digital/gitlab-mcp-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoda.digital/gitlab-mcp-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Release 0.9.1 - Dependency hygiene + E2E test resilience

Pure infra + test hardening chore release on top of 0.9.0. Zero MCP source-code changes.

## Bumps (8 Dependabot PRs)

| PR | Bump | Type |
|----|------|------|
| #87 | `qs` 6.14.2 → 6.15.2 | npm patch (transitive) |
| #88 | `node` Docker base digest `e71ac5e` → `7c6af15` | Docker |
| #94 | `vitest` 4.1.6 → 4.1.7 | dev-dep patch |
| #89 | `docker/setup-buildx-action` 4.0.0 → 4.1.0 | GH Action minor |
| **#90** | **`actions/checkout` 4 → 6** | **GH Action MAJOR** |
| **#91** | **`docker/build-push-action` 6.19.2 → 7.2.0** | **GH Action MAJOR** |
| **#92** | **`docker/login-action` 3 → 4** | **GH Action MAJOR** |
| **#93** | **`docker/setup-qemu-action` 3.7.0 → 4.0.0** | **GH Action MAJOR** |

All 4 MAJOR GH Action bumps verified via upstream changelog review. Common theme: Node 24 runtime requirement (ubuntu-latest runners v2.327.1+ satisfy). `docker/build-push-action` v7 drops deprecated `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs - confirmed not used in this repo. Dependabot updated SHA-pins on the OIDC-scoped `docker` job within each PR.

## Fixed

- **#101 `fix(e2e): tolerate empty trace at 3s timing window`** - the `get_job_log_smart` E2E test was timing-fragile: it asserted `line_count > 0` after a fixed 3-second wait for the GitLab CE runner to flush trace. The Node digest bump in #88 + GH Actions runner-image shift moved timing by ~50-100ms, flipping the test from intermittently-passing to consistently-failing on the immediate post-batch runs. **Proof of timing-fragility**: same commit `308f97f5` had 8 consecutive E2E FAILURE runs (11:34-11:37 UTC) followed by 2 SUCCESS runs (11:48-11:49 UTC) without any code change. Fix mirrors the existing 404 "trace not available" catch in the same test - on empty `line_count`, skip content assertions with `console.warn`. Shape correctness still asserted when trace IS populated.

## Verification

- [x] `package.json` 0.9.0 → 0.9.1
- [x] `package-lock.json` regenerated
- [x] CHANGELOG `[0.9.1] - 2026-05-27` block with full Dependabot + E2E fix details
- [x] Build clean (`tsc`)
- [x] 104/104 unit tests pass (`vitest run`)
- [x] E2E on post-fix HEAD `3ffa012` = SUCCESS (verified before opening this PR)

## Merge plan

Single-commit ceremony PR - **squash merge** per repo convention. After merge:
1. Tag `v0.9.1` via `gh release create` → triggers `publish.yml` on `release.published` → npm
2. Same tag triggers `build.yml` on push → ghcr multi-arch + helm + cosign attest + Trivy
